### PR TITLE
Add GitHub Gists feature

### DIFF
--- a/app/components/gists/CreateGistModal.tsx
+++ b/app/components/gists/CreateGistModal.tsx
@@ -1,0 +1,225 @@
+"use client";
+
+import { useState } from "react";
+import { useGitHub } from "../../context/GitHubContext";
+
+interface GistFile {
+  filename: string;
+  content: string;
+}
+
+interface CreateGistModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onGistCreated: (gist: any) => void;
+}
+
+export default function CreateGistModal({ isOpen, onClose, onGistCreated }: CreateGistModalProps) {
+  const { githubService } = useGitHub();
+  const [description, setDescription] = useState("");
+  const [isPublic, setIsPublic] = useState(true);
+  const [files, setFiles] = useState<GistFile[]>([{ filename: "", content: "" }]);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  if (!isOpen) return null;
+
+  const handleAddFile = () => {
+    setFiles([...files, { filename: "", content: "" }]);
+  };
+
+  const handleRemoveFile = (index: number) => {
+    if (files.length === 1) return;
+    const newFiles = [...files];
+    newFiles.splice(index, 1);
+    setFiles(newFiles);
+  };
+
+  const handleFileChange = (index: number, field: keyof GistFile, value: string) => {
+    const newFiles = [...files];
+    newFiles[index][field] = value;
+    setFiles(newFiles);
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    
+    // Validate form
+    if (!files.some(file => file.filename && file.content)) {
+      setError("At least one file with a filename and content is required");
+      return;
+    }
+    
+    if (!githubService) {
+      setError("GitHub service is not available");
+      return;
+    }
+    
+    try {
+      setIsSubmitting(true);
+      setError(null);
+      
+      // Convert files array to the format expected by the GitHub API
+      const filesObject: Record<string, { content: string }> = {};
+      files.forEach(file => {
+        if (file.filename && file.content) {
+          filesObject[file.filename] = { content: file.content };
+        }
+      });
+      
+      const gist = await githubService.createGist({
+        description,
+        files: filesObject,
+        public: isPublic,
+      });
+      
+      onGistCreated(gist);
+      onClose();
+      
+      // Reset form
+      setDescription("");
+      setIsPublic(true);
+      setFiles([{ filename: "", content: "" }]);
+    } catch (err) {
+      console.error("Error creating gist:", err);
+      setError("Failed to create gist. Please try again.");
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4">
+      <div className="bg-white dark:bg-gray-800 rounded-lg shadow-xl w-full max-w-3xl max-h-[90vh] overflow-y-auto">
+        <div className="p-4 border-b border-gray-200 dark:border-gray-700 flex justify-between items-center">
+          <h2 className="text-xl font-semibold">Create New Gist</h2>
+          <button
+            onClick={onClose}
+            className="text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200"
+          >
+            <svg xmlns="http://www.w3.org/2000/svg" className="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
+        </div>
+        
+        <form onSubmit={handleSubmit} className="p-4">
+          {error && (
+            <div className="mb-4 p-3 bg-red-100 dark:bg-red-900 text-red-800 dark:text-red-200 rounded-md">
+              {error}
+            </div>
+          )}
+          
+          <div className="mb-4">
+            <label htmlFor="description" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+              Description (optional)
+            </label>
+            <input
+              type="text"
+              id="description"
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500 dark:bg-gray-700 dark:text-white"
+              placeholder="Enter gist description"
+            />
+          </div>
+          
+          <div className="mb-4">
+            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+              Visibility
+            </label>
+            <div className="flex items-center space-x-4">
+              <label className="inline-flex items-center">
+                <input
+                  type="radio"
+                  checked={isPublic}
+                  onChange={() => setIsPublic(true)}
+                  className="form-radio h-4 w-4 text-blue-600"
+                />
+                <span className="ml-2 text-gray-700 dark:text-gray-300">Public</span>
+              </label>
+              <label className="inline-flex items-center">
+                <input
+                  type="radio"
+                  checked={!isPublic}
+                  onChange={() => setIsPublic(false)}
+                  className="form-radio h-4 w-4 text-blue-600"
+                />
+                <span className="ml-2 text-gray-700 dark:text-gray-300">Secret</span>
+              </label>
+            </div>
+          </div>
+          
+          <div className="mb-4">
+            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+              Files
+            </label>
+            {files.map((file, index) => (
+              <div key={index} className="mb-4 p-3 border border-gray-200 dark:border-gray-700 rounded-md">
+                <div className="flex justify-between items-center mb-2">
+                  <input
+                    type="text"
+                    value={file.filename}
+                    onChange={(e) => handleFileChange(index, "filename", e.target.value)}
+                    className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500 dark:bg-gray-700 dark:text-white"
+                    placeholder="Filename including extension"
+                    required
+                  />
+                  <button
+                    type="button"
+                    onClick={() => handleRemoveFile(index)}
+                    disabled={files.length === 1}
+                    className={`ml-2 p-1 rounded-md ${
+                      files.length === 1
+                        ? "text-gray-400 cursor-not-allowed"
+                        : "text-red-500 hover:bg-red-100 dark:hover:bg-red-900"
+                    }`}
+                  >
+                    <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5" viewBox="0 0 20 20" fill="currentColor">
+                      <path fillRule="evenodd" d="M9 2a1 1 0 00-.894.553L7.382 4H4a1 1 0 000 2v10a2 2 0 002 2h8a2 2 0 002-2V6a1 1 0 100-2h-3.382l-.724-1.447A1 1 0 0011 2H9zM7 8a1 1 0 012 0v6a1 1 0 11-2 0V8zm5-1a1 1 0 00-1 1v6a1 1 0 102 0V8a1 1 0 00-1-1z" clipRule="evenodd" />
+                    </svg>
+                  </button>
+                </div>
+                <textarea
+                  value={file.content}
+                  onChange={(e) => handleFileChange(index, "content", e.target.value)}
+                  className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500 dark:bg-gray-700 dark:text-white font-mono text-sm"
+                  placeholder="File content"
+                  rows={8}
+                  required
+                />
+              </div>
+            ))}
+            <button
+              type="button"
+              onClick={handleAddFile}
+              className="text-blue-600 dark:text-blue-400 hover:text-blue-800 dark:hover:text-blue-300 flex items-center"
+            >
+              <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5 mr-1" viewBox="0 0 20 20" fill="currentColor">
+                <path fillRule="evenodd" d="M10 5a1 1 0 011 1v3h3a1 1 0 110 2h-3v3a1 1 0 11-2 0v-3H6a1 1 0 110-2h3V6a1 1 0 011-1z" clipRule="evenodd" />
+              </svg>
+              Add another file
+            </button>
+          </div>
+          
+          <div className="flex justify-end space-x-3 mt-6">
+            <button
+              type="button"
+              onClick={onClose}
+              className="px-4 py-2 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm text-sm font-medium text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-700 hover:bg-gray-50 dark:hover:bg-gray-600 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500"
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              disabled={isSubmitting}
+              className="px-4 py-2 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              {isSubmitting ? "Creating..." : "Create Gist"}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/app/components/gists/GistCard.tsx
+++ b/app/components/gists/GistCard.tsx
@@ -1,0 +1,190 @@
+"use client";
+
+import Link from "next/link";
+import { useState } from "react";
+import { useGitHub } from "../../context/GitHubContext";
+
+interface GistFile {
+  filename: string;
+  language: string;
+  raw_url: string;
+  size: number;
+  type: string;
+  content?: string;
+}
+
+interface GistOwner {
+  login: string;
+  avatar_url: string;
+  html_url: string;
+}
+
+export interface Gist {
+  id: string;
+  description: string;
+  public: boolean;
+  created_at: string;
+  updated_at: string;
+  files: Record<string, GistFile>;
+  owner: GistOwner;
+  html_url: string;
+  comments: number;
+}
+
+interface GistCardProps {
+  gist: Gist;
+  onDelete?: (gistId: string) => void;
+}
+
+export default function GistCard({ gist, onDelete }: GistCardProps) {
+  const { githubService } = useGitHub();
+  const [isStarred, setIsStarred] = useState<boolean | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+
+  // Get the first file for preview
+  const fileNames = Object.keys(gist.files);
+  const firstFileName = fileNames[0];
+  const firstFile = gist.files[firstFileName];
+  
+  // Format date
+  const formatDate = (dateString: string) => {
+    const date = new Date(dateString);
+    return date.toLocaleDateString("en-US", {
+      year: "numeric",
+      month: "short",
+      day: "numeric",
+    });
+  };
+
+  // Check if gist is starred
+  const checkIfStarred = async () => {
+    if (!githubService || isStarred !== null) return;
+    
+    try {
+      setIsLoading(true);
+      const starred = await githubService.isGistStarred(gist.id);
+      setIsStarred(starred);
+    } catch (error) {
+      console.error("Error checking if gist is starred:", error);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  // Toggle star status
+  const toggleStar = async () => {
+    if (!githubService) return;
+    
+    try {
+      setIsLoading(true);
+      
+      if (isStarred) {
+        await githubService.unstarGist(gist.id);
+        setIsStarred(false);
+      } else {
+        await githubService.starGist(gist.id);
+        setIsStarred(true);
+      }
+    } catch (error) {
+      console.error("Error toggling star status:", error);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  // Handle delete
+  const handleDelete = async () => {
+    if (!githubService || !onDelete) return;
+    
+    if (window.confirm("Are you sure you want to delete this gist?")) {
+      try {
+        setIsLoading(true);
+        await githubService.deleteGist(gist.id);
+        onDelete(gist.id);
+      } catch (error) {
+        console.error("Error deleting gist:", error);
+        alert("Failed to delete gist. Please try again.");
+      } finally {
+        setIsLoading(false);
+      }
+    }
+  };
+
+  return (
+    <div 
+      className="bg-white dark:bg-gray-800 rounded-lg shadow-md overflow-hidden hover:shadow-lg transition-shadow"
+      onMouseEnter={checkIfStarred}
+    >
+      <div className="p-4 border-b border-gray-200 dark:border-gray-700">
+        <div className="flex justify-between items-start mb-2">
+          <Link href={`/gists/${gist.id}`} className="text-lg font-semibold text-blue-600 dark:text-blue-400 hover:underline">
+            {gist.description || `Gist:${gist.id.substring(0, 7)}`}
+          </Link>
+          <div className="flex space-x-2">
+            {isStarred !== null && (
+              <button
+                onClick={toggleStar}
+                disabled={isLoading}
+                className="text-gray-500 dark:text-gray-400 hover:text-yellow-500 dark:hover:text-yellow-400"
+                title={isStarred ? "Unstar this gist" : "Star this gist"}
+              >
+                <svg xmlns="http://www.w3.org/2000/svg" className={`h-5 w-5 ${isStarred ? "text-yellow-500 fill-current" : ""}`} viewBox="0 0 20 20" fill={isStarred ? "currentColor" : "none"} stroke="currentColor">
+                  <path d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 0 00.951-.69l1.07-3.292z" />
+                </svg>
+              </button>
+            )}
+            {onDelete && (
+              <button
+                onClick={handleDelete}
+                disabled={isLoading}
+                className="text-gray-500 dark:text-gray-400 hover:text-red-500 dark:hover:text-red-400"
+                title="Delete this gist"
+              >
+                <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5" viewBox="0 0 20 20" fill="none" stroke="currentColor">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+                </svg>
+              </button>
+            )}
+          </div>
+        </div>
+        <div className="flex items-center text-sm text-gray-600 dark:text-gray-400 mb-2">
+          <img src={gist.owner.avatar_url} alt={gist.owner.login} className="w-5 h-5 rounded-full mr-2" />
+          <span>{gist.owner.login}</span>
+          <span className="mx-2">•</span>
+          <span>Created: {formatDate(gist.created_at)}</span>
+          {gist.updated_at !== gist.created_at && (
+            <>
+              <span className="mx-2">•</span>
+              <span>Updated: {formatDate(gist.updated_at)}</span>
+            </>
+          )}
+        </div>
+        <div className="flex items-center text-xs text-gray-500 dark:text-gray-500">
+          <span className={`px-2 py-1 rounded ${gist.public ? "bg-green-100 dark:bg-green-900 text-green-800 dark:text-green-200" : "bg-yellow-100 dark:bg-yellow-900 text-yellow-800 dark:text-yellow-200"}`}>
+            {gist.public ? "Public" : "Secret"}
+          </span>
+          <span className="ml-2">{fileNames.length} {fileNames.length === 1 ? "file" : "files"}</span>
+          {gist.comments > 0 && (
+            <span className="ml-2">{gist.comments} {gist.comments === 1 ? "comment" : "comments"}</span>
+          )}
+        </div>
+      </div>
+      <div className="p-4 bg-gray-50 dark:bg-gray-900 overflow-x-auto">
+        <div className="flex items-center justify-between mb-2">
+          <div className="flex items-center">
+            <span className="text-sm font-medium text-gray-700 dark:text-gray-300">{firstFileName}</span>
+            {firstFile.language && (
+              <span className="ml-2 px-2 py-0.5 text-xs rounded bg-blue-100 dark:bg-blue-900 text-blue-800 dark:text-blue-200">
+                {firstFile.language}
+              </span>
+            )}
+          </div>
+          <span className="text-xs text-gray-500 dark:text-gray-400">{firstFile.size} bytes</span>
+        </div>
+        <pre className="text-sm overflow-x-auto p-2 bg-gray-100 dark:bg-gray-800 rounded">
+          <code>{firstFile.content ? firstFile.content.slice(0, 200) + (firstFile.content.length > 200 ? "..." : "") : "Content not loaded"}</code>
+        </pre>
+      </div>
+    </div>
+  );
+}

--- a/app/components/gists/GistViewer.tsx
+++ b/app/components/gists/GistViewer.tsx
@@ -1,0 +1,336 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { useGitHub } from "../../context/GitHubContext";
+
+interface GistFile {
+  filename: string;
+  language: string;
+  raw_url: string;
+  size: number;
+  type: string;
+  content?: string;
+}
+
+interface GistOwner {
+  login: string;
+  avatar_url: string;
+  html_url: string;
+}
+
+interface Gist {
+  id: string;
+  description: string;
+  public: boolean;
+  created_at: string;
+  updated_at: string;
+  files: Record<string, GistFile>;
+  owner: GistOwner;
+  html_url: string;
+  comments: number;
+}
+
+interface GistComment {
+  id: number;
+  body: string;
+  user: {
+    login: string;
+    avatar_url: string;
+  };
+  created_at: string;
+  updated_at: string;
+}
+
+interface GistViewerProps {
+  gistId: string;
+}
+
+export default function GistViewer({ gistId }: GistViewerProps) {
+  const { githubService } = useGitHub();
+  const [gist, setGist] = useState<Gist | null>(null);
+  const [comments, setComments] = useState<GistComment[]>([]);
+  const [activeFile, setActiveFile] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [isStarred, setIsStarred] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [newComment, setNewComment] = useState("");
+  const [isSubmittingComment, setIsSubmittingComment] = useState(false);
+
+  // Fetch gist data
+  useEffect(() => {
+    async function fetchGist() {
+      if (!githubService) return;
+      
+      try {
+        setIsLoading(true);
+        setError(null);
+        
+        const gistData = await githubService.getGist(gistId);
+        setGist(gistData);
+        
+        // Set the first file as active by default
+        const fileNames = Object.keys(gistData.files);
+        if (fileNames.length > 0 && !activeFile) {
+          setActiveFile(fileNames[0]);
+        }
+        
+        // Check if gist is starred
+        const starred = await githubService.isGistStarred(gistId);
+        setIsStarred(starred);
+        
+        // Fetch comments
+        const commentsData = await githubService.getGistComments(gistId);
+        setComments(commentsData);
+      } catch (err) {
+        console.error("Error fetching gist:", err);
+        setError("Failed to load gist. Please try again later.");
+      } finally {
+        setIsLoading(false);
+      }
+    }
+    
+    fetchGist();
+  }, [githubService, gistId, activeFile]);
+
+  // Format date
+  const formatDate = (dateString: string) => {
+    const date = new Date(dateString);
+    return date.toLocaleDateString("en-US", {
+      year: "numeric",
+      month: "short",
+      day: "numeric",
+      hour: "2-digit",
+      minute: "2-digit",
+    });
+  };
+
+  // Toggle star status
+  const toggleStar = async () => {
+    if (!githubService) return;
+    
+    try {
+      if (isStarred) {
+        await githubService.unstarGist(gistId);
+        setIsStarred(false);
+      } else {
+        await githubService.starGist(gistId);
+        setIsStarred(true);
+      }
+    } catch (error) {
+      console.error("Error toggling star status:", error);
+    }
+  };
+
+  // Submit comment
+  const handleSubmitComment = async (e: React.FormEvent) => {
+    e.preventDefault();
+    
+    if (!githubService || !newComment.trim()) return;
+    
+    try {
+      setIsSubmittingComment(true);
+      
+      const comment = await githubService.createGistComment(gistId, newComment);
+      setComments([...comments, comment]);
+      setNewComment("");
+    } catch (err) {
+      console.error("Error creating comment:", err);
+      alert("Failed to post comment. Please try again.");
+    } finally {
+      setIsSubmittingComment(false);
+    }
+  };
+
+  // Delete comment
+  const handleDeleteComment = async (commentId: number) => {
+    if (!githubService) return;
+    
+    if (window.confirm("Are you sure you want to delete this comment?")) {
+      try {
+        await githubService.deleteGistComment(gistId, commentId);
+        setComments(comments.filter(comment => comment.id !== commentId));
+      } catch (err) {
+        console.error("Error deleting comment:", err);
+        alert("Failed to delete comment. Please try again.");
+      }
+    }
+  };
+
+  if (isLoading) {
+    return (
+      <div className="flex justify-center items-center h-64">
+        <div className="animate-spin rounded-full h-12 w-12 border-t-2 border-b-2 border-blue-500"></div>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="bg-red-100 dark:bg-red-900 text-red-800 dark:text-red-200 p-4 rounded-md">
+        {error}
+      </div>
+    );
+  }
+
+  if (!gist) {
+    return (
+      <div className="bg-yellow-100 dark:bg-yellow-900 text-yellow-800 dark:text-yellow-200 p-4 rounded-md">
+        Gist not found.
+      </div>
+    );
+  }
+
+  const fileNames = Object.keys(gist.files);
+  const currentFile = activeFile ? gist.files[activeFile] : null;
+
+  return (
+    <div className="bg-white dark:bg-gray-800 rounded-lg shadow-md overflow-hidden">
+      <div className="p-4 border-b border-gray-200 dark:border-gray-700">
+        <div className="flex justify-between items-start mb-4">
+          <h1 className="text-xl font-semibold">
+            {gist.description || `Gist:${gist.id.substring(0, 7)}`}
+          </h1>
+          <div className="flex space-x-2">
+            <button
+              onClick={toggleStar}
+              className="text-gray-500 dark:text-gray-400 hover:text-yellow-500 dark:hover:text-yellow-400"
+              title={isStarred ? "Unstar this gist" : "Star this gist"}
+            >
+              <svg xmlns="http://www.w3.org/2000/svg" className={`h-5 w-5 ${isStarred ? "text-yellow-500 fill-current" : ""}`} viewBox="0 0 20 20" fill={isStarred ? "currentColor" : "none"} stroke="currentColor">
+                <path d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 0 00.951-.69l1.07-3.292z" />
+              </svg>
+            </button>
+            <a
+              href={gist.html_url}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-gray-500 dark:text-gray-400 hover:text-blue-500 dark:hover:text-blue-400"
+              title="View on GitHub"
+            >
+              <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5" viewBox="0 0 20 20" fill="currentColor">
+                <path d="M11 3a1 1 0 100 2h2.586l-6.293 6.293a1 1 0 101.414 1.414L15 6.414V9a1 1 0 102 0V4a1 1 0 00-1-1h-5z" />
+                <path d="M5 5a2 2 0 00-2 2v8a2 2 0 002 2h8a2 2 0 002-2v-3a1 1 0 10-2 0v3H5V7h3a1 1 0 000-2H5z" />
+              </svg>
+            </a>
+          </div>
+        </div>
+        <div className="flex items-center text-sm text-gray-600 dark:text-gray-400 mb-2">
+          <img src={gist.owner.avatar_url} alt={gist.owner.login} className="w-5 h-5 rounded-full mr-2" />
+          <a href={gist.owner.html_url} target="_blank" rel="noopener noreferrer" className="hover:underline">
+            {gist.owner.login}
+          </a>
+          <span className="mx-2">•</span>
+          <span>Created: {formatDate(gist.created_at)}</span>
+          {gist.updated_at !== gist.created_at && (
+            <>
+              <span className="mx-2">•</span>
+              <span>Updated: {formatDate(gist.updated_at)}</span>
+            </>
+          )}
+        </div>
+        <div className="flex items-center text-xs text-gray-500 dark:text-gray-500">
+          <span className={`px-2 py-1 rounded ${gist.public ? "bg-green-100 dark:bg-green-900 text-green-800 dark:text-green-200" : "bg-yellow-100 dark:bg-yellow-900 text-yellow-800 dark:text-yellow-200"}`}>
+            {gist.public ? "Public" : "Secret"}
+          </span>
+          <span className="ml-2">{fileNames.length} {fileNames.length === 1 ? "file" : "files"}</span>
+        </div>
+      </div>
+      
+      <div className="border-b border-gray-200 dark:border-gray-700">
+        <div className="flex overflow-x-auto">
+          {fileNames.map(fileName => (
+            <button
+              key={fileName}
+              onClick={() => setActiveFile(fileName)}
+              className={`px-4 py-2 text-sm font-medium whitespace-nowrap ${
+                activeFile === fileName
+                  ? "border-b-2 border-blue-500 text-blue-600 dark:text-blue-400"
+                  : "text-gray-600 dark:text-gray-400 hover:text-gray-800 dark:hover:text-gray-200"
+              }`}
+            >
+              {fileName}
+            </button>
+          ))}
+        </div>
+      </div>
+      
+      {currentFile && (
+        <div className="p-4 bg-gray-50 dark:bg-gray-900 overflow-x-auto">
+          <div className="flex items-center justify-between mb-2">
+            <div className="flex items-center">
+              <span className="text-sm font-medium text-gray-700 dark:text-gray-300">{currentFile.filename}</span>
+              {currentFile.language && (
+                <span className="ml-2 px-2 py-0.5 text-xs rounded bg-blue-100 dark:bg-blue-900 text-blue-800 dark:text-blue-200">
+                  {currentFile.language}
+                </span>
+              )}
+            </div>
+            <span className="text-xs text-gray-500 dark:text-gray-400">{currentFile.size} bytes</span>
+          </div>
+          <pre className="text-sm overflow-x-auto p-4 bg-gray-100 dark:bg-gray-800 rounded border border-gray-200 dark:border-gray-700">
+            <code>{currentFile.content || "Content not loaded"}</code>
+          </pre>
+        </div>
+      )}
+      
+      <div className="p-4 border-t border-gray-200 dark:border-gray-700">
+        <h2 className="text-lg font-semibold mb-4">Comments ({comments.length})</h2>
+        
+        <form onSubmit={handleSubmitComment} className="mb-6">
+          <textarea
+            value={newComment}
+            onChange={(e) => setNewComment(e.target.value)}
+            className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500 dark:bg-gray-700 dark:text-white"
+            placeholder="Leave a comment"
+            rows={3}
+            required
+          />
+          <div className="mt-2 flex justify-end">
+            <button
+              type="submit"
+              disabled={isSubmittingComment || !newComment.trim()}
+              className="px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              {isSubmittingComment ? "Posting..." : "Post Comment"}
+            </button>
+          </div>
+        </form>
+        
+        {comments.length > 0 ? (
+          <div className="space-y-4">
+            {comments.map(comment => (
+              <div key={comment.id} className="p-4 bg-gray-50 dark:bg-gray-900 rounded-md">
+                <div className="flex justify-between items-start mb-2">
+                  <div className="flex items-center">
+                    <img src={comment.user.avatar_url} alt={comment.user.login} className="w-6 h-6 rounded-full mr-2" />
+                    <span className="font-medium text-gray-800 dark:text-gray-200">{comment.user.login}</span>
+                    <span className="ml-2 text-xs text-gray-500 dark:text-gray-400">
+                      {formatDate(comment.created_at)}
+                      {comment.updated_at !== comment.created_at && " (edited)"}
+                    </span>
+                  </div>
+                  <button
+                    onClick={() => handleDeleteComment(comment.id)}
+                    className="text-gray-500 dark:text-gray-400 hover:text-red-500 dark:hover:text-red-400"
+                    title="Delete comment"
+                  >
+                    <svg xmlns="http://www.w3.org/2000/svg" className="h-4 w-4" viewBox="0 0 20 20" fill="currentColor">
+                      <path fillRule="evenodd" d="M9 2a1 1 0 00-.894.553L7.382 4H4a1 1 0 000 2v10a2 2 0 002 2h8a2 2 0 002-2V6a1 1 0 100-2h-3.382l-.724-1.447A1 1 0 0011 2H9zM7 8a1 1 0 012 0v6a1 1 0 11-2 0V8zm5-1a1 1 0 00-1 1v6a1 1 0 102 0V8a1 1 0 00-1-1z" clipRule="evenodd" />
+                    </svg>
+                  </button>
+                </div>
+                <div className="text-gray-700 dark:text-gray-300 whitespace-pre-wrap">
+                  {comment.body}
+                </div>
+              </div>
+            ))}
+          </div>
+        ) : (
+          <div className="text-center text-gray-500 dark:text-gray-400 py-4">
+            No comments yet. Be the first to comment!
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/app/components/layout/Header.tsx
+++ b/app/components/layout/Header.tsx
@@ -56,6 +56,9 @@ const Header: FC = () => {
               <Link href="/pull-requests" className="hover:text-gray-300 transition-colors">
                 Pull Requests
               </Link>
+              <Link href="/gists" className="hover:text-gray-300 transition-colors">
+                Gists
+              </Link>
               <Link href="/actions" className="hover:text-gray-300 transition-colors">
                 Actions
               </Link>

--- a/app/components/layout/Sidebar.tsx
+++ b/app/components/layout/Sidebar.tsx
@@ -94,6 +94,18 @@ const Sidebar: FC<SidebarProps> = ({ isOpen, onClose }) => {
                 </li>
                 <li>
                   <Link
+                    href="/gists"
+                    className="flex items-center space-x-2 p-2 rounded-md hover:bg-gray-700 transition-colors"
+                    onClick={() => onClose()}
+                  >
+                    <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5" viewBox="0 0 20 20" fill="currentColor">
+                      <path fillRule="evenodd" d="M4 4a2 2 0 012-2h4.586A2 2 0 0112 2.586L15.414 6A2 2 0 0116 7.414V16a2 2 0 01-2 2H6a2 2 0 01-2-2V4zm2 6a1 1 0 011-1h6a1 1 0 110 2H7a1 1 0 01-1-1zm1 3a1 1 0 100 2h6a1 1 0 100-2H7z" clipRule="evenodd" />
+                    </svg>
+                    <span>Gists</span>
+                  </Link>
+                </li>
+                <li>
+                  <Link
                     href="/actions"
                     className="flex items-center space-x-2 p-2 rounded-md hover:bg-gray-700 transition-colors"
                     onClick={() => onClose()}

--- a/app/gists/[id]/page.tsx
+++ b/app/gists/[id]/page.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+import { useParams } from "next/navigation";
+import MainLayout from "../../components/layout/MainLayout";
+import GistViewer from "../../components/gists/GistViewer";
+import Link from "next/link";
+
+export default function GistPage() {
+  const params = useParams();
+  const gistId = params.id as string;
+
+  return (
+    <MainLayout>
+      <div className="container mx-auto py-6">
+        <div className="mb-6">
+          <Link
+            href="/gists"
+            className="text-blue-600 dark:text-blue-400 hover:underline flex items-center"
+          >
+            <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5 mr-1" viewBox="0 0 20 20" fill="currentColor">
+              <path fillRule="evenodd" d="M12.707 5.293a1 1 0 010 1.414L9.414 10l3.293 3.293a1 1 0 01-1.414 1.414l-4-4a1 1 0 010-1.414l4-4a1 1 0 011.414 0z" clipRule="evenodd" />
+            </svg>
+            Back to Gists
+          </Link>
+        </div>
+        
+        <GistViewer gistId={gistId} />
+      </div>
+    </MainLayout>
+  );
+}

--- a/app/gists/page.tsx
+++ b/app/gists/page.tsx
@@ -1,0 +1,171 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { useGitHub } from "../context/GitHubContext";
+import MainLayout from "../components/layout/MainLayout";
+import GistCard, { Gist } from "../components/gists/GistCard";
+import CreateGistModal from "../components/gists/CreateGistModal";
+
+export default function GistsPage() {
+  const { githubService, isLoading: githubLoading } = useGitHub();
+  const [gists, setGists] = useState<Gist[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [activeTab, setActiveTab] = useState<"your" | "starred" | "public">("your");
+  const [showCreateModal, setShowCreateModal] = useState(false);
+
+  // Fetch gists based on active tab
+  useEffect(() => {
+    async function fetchGists() {
+      if (githubService && !githubLoading) {
+        try {
+          setIsLoading(true);
+          setError(null);
+          
+          let gistsData: Gist[] = [];
+          
+          switch (activeTab) {
+            case "your":
+              gistsData = await githubService.getGists(1, 100);
+              break;
+            case "starred":
+              gistsData = await githubService.getStarredGists(1, 100);
+              break;
+            case "public":
+              gistsData = await githubService.getPublicGists(1, 100);
+              break;
+          }
+          
+          setGists(gistsData);
+        } catch (err) {
+          console.error("Error fetching gists:", err);
+          setError("Failed to fetch gists. Please try again later.");
+        } finally {
+          setIsLoading(false);
+        }
+      }
+    }
+    
+    fetchGists();
+  }, [githubService, githubLoading, activeTab]);
+
+  // Handle gist creation
+  const handleGistCreated = (newGist: Gist) => {
+    if (activeTab === "your") {
+      setGists([newGist, ...gists]);
+    }
+  };
+
+  // Handle gist deletion
+  const handleGistDeleted = (gistId: string) => {
+    setGists(gists.filter(gist => gist.id !== gistId));
+  };
+
+  return (
+    <MainLayout>
+      <div className="container mx-auto py-6">
+        <div className="flex justify-between items-center mb-6">
+          <h1 className="text-2xl font-bold">GitHub Gists</h1>
+          <button
+            onClick={() => setShowCreateModal(true)}
+            className="bg-blue-600 hover:bg-blue-700 text-white font-medium py-2 px-4 rounded-lg transition-colors flex items-center"
+          >
+            <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5 mr-1" viewBox="0 0 20 20" fill="currentColor">
+              <path fillRule="evenodd" d="M10 5a1 1 0 011 1v3h3a1 1 0 110 2h-3v3a1 1 0 11-2 0v-3H6a1 1 0 110-2h3V6a1 1 0 011-1z" clipRule="evenodd" />
+            </svg>
+            Create Gist
+          </button>
+        </div>
+
+        <div className="mb-6">
+          <div className="border-b border-gray-200 dark:border-gray-700">
+            <nav className="flex space-x-8">
+              <button
+                onClick={() => setActiveTab("your")}
+                className={`py-4 px-1 border-b-2 font-medium text-sm ${
+                  activeTab === "your"
+                    ? "border-blue-500 text-blue-600 dark:text-blue-400"
+                    : "border-transparent text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-300"
+                }`}
+              >
+                Your Gists
+              </button>
+              <button
+                onClick={() => setActiveTab("starred")}
+                className={`py-4 px-1 border-b-2 font-medium text-sm ${
+                  activeTab === "starred"
+                    ? "border-blue-500 text-blue-600 dark:text-blue-400"
+                    : "border-transparent text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-300"
+                }`}
+              >
+                Starred
+              </button>
+              <button
+                onClick={() => setActiveTab("public")}
+                className={`py-4 px-1 border-b-2 font-medium text-sm ${
+                  activeTab === "public"
+                    ? "border-blue-500 text-blue-600 dark:text-blue-400"
+                    : "border-transparent text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-300"
+                }`}
+              >
+                Public
+              </button>
+            </nav>
+          </div>
+        </div>
+
+        {error && (
+          <div className="bg-red-100 dark:bg-red-900 text-red-800 dark:text-red-200 p-4 rounded-md mb-6">
+            {error}
+          </div>
+        )}
+
+        {isLoading ? (
+          <div className="flex justify-center items-center h-64">
+            <div className="animate-spin rounded-full h-12 w-12 border-t-2 border-b-2 border-blue-500"></div>
+          </div>
+        ) : gists.length > 0 ? (
+          <div className="grid grid-cols-1 gap-6">
+            {gists.map(gist => (
+              <GistCard
+                key={gist.id}
+                gist={gist}
+                onDelete={activeTab === "your" ? handleGistDeleted : undefined}
+              />
+            ))}
+          </div>
+        ) : (
+          <div className="text-center py-12">
+            <svg xmlns="http://www.w3.org/2000/svg" className="h-16 w-16 mx-auto text-gray-400 dark:text-gray-600 mb-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1} d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
+            </svg>
+            <h3 className="text-lg font-medium text-gray-900 dark:text-gray-100 mb-2">No gists found</h3>
+            <p className="text-gray-500 dark:text-gray-400 mb-6">
+              {activeTab === "your"
+                ? "You haven't created any gists yet."
+                : activeTab === "starred"
+                ? "You haven't starred any gists yet."
+                : "No public gists found."}
+            </p>
+            {activeTab === "your" && (
+              <button
+                onClick={() => setShowCreateModal(true)}
+                className="bg-blue-600 hover:bg-blue-700 text-white font-medium py-2 px-4 rounded-lg transition-colors"
+              >
+                Create your first gist
+              </button>
+            )}
+          </div>
+        )}
+      </div>
+
+      {showCreateModal && (
+        <CreateGistModal
+          isOpen={showCreateModal}
+          onClose={() => setShowCreateModal(false)}
+          onGistCreated={handleGistCreated}
+        />
+      )}
+    </MainLayout>
+  );
+}

--- a/app/services/github/githubService.ts
+++ b/app/services/github/githubService.ts
@@ -307,4 +307,118 @@ export class GitHubService {
     });
     return data;
   }
+
+  // Gists methods
+  async getGists(page = 1, perPage = 10) {
+    const { data } = await this.octokit.rest.gists.list({
+      per_page: perPage,
+      page,
+    });
+    return data;
+  }
+
+  async getStarredGists(page = 1, perPage = 10) {
+    const { data } = await this.octokit.rest.gists.listStarred({
+      per_page: perPage,
+      page,
+    });
+    return data;
+  }
+
+  async getPublicGists(page = 1, perPage = 10) {
+    const { data } = await this.octokit.rest.gists.listPublic({
+      per_page: perPage,
+      page,
+    });
+    return data;
+  }
+
+  async getGist(gistId: string) {
+    const { data } = await this.octokit.rest.gists.get({
+      gist_id: gistId,
+    });
+    return data;
+  }
+
+  async createGist(options: {
+    description?: string;
+    files: Record<string, { content: string }>;
+    public?: boolean;
+  }) {
+    const { data } = await this.octokit.rest.gists.create({
+      description: options.description,
+      files: options.files,
+      public: options.public,
+    });
+    return data;
+  }
+
+  async updateGist(gistId: string, options: {
+    description?: string;
+    files: Record<string, { content: string } | null>;
+  }) {
+    const { data } = await this.octokit.rest.gists.update({
+      gist_id: gistId,
+      description: options.description,
+      files: options.files,
+    });
+    return data;
+  }
+
+  async deleteGist(gistId: string) {
+    const { data } = await this.octokit.rest.gists.delete({
+      gist_id: gistId,
+    });
+    return data;
+  }
+
+  async starGist(gistId: string) {
+    const { data } = await this.octokit.rest.gists.star({
+      gist_id: gistId,
+    });
+    return data;
+  }
+
+  async unstarGist(gistId: string) {
+    const { data } = await this.octokit.rest.gists.unstar({
+      gist_id: gistId,
+    });
+    return data;
+  }
+
+  async isGistStarred(gistId: string) {
+    try {
+      await this.octokit.rest.gists.checkIsStarred({
+        gist_id: gistId,
+      });
+      return true;
+    } catch (error) {
+      return false;
+    }
+  }
+
+  async getGistComments(gistId: string, page = 1, perPage = 100) {
+    const { data } = await this.octokit.rest.gists.listComments({
+      gist_id: gistId,
+      per_page: perPage,
+      page,
+    });
+    return data;
+  }
+
+  async createGistComment(gistId: string, body: string) {
+    const { data } = await this.octokit.rest.gists.createComment({
+      gist_id: gistId,
+      body,
+    });
+    return data;
+  }
+
+  async deleteGistComment(gistId: string, commentId: number) {
+    const { data } = await this.octokit.rest.gists.deleteComment({
+      gist_id: gistId,
+      comment_id: commentId,
+    });
+    return data;
+  }
 }


### PR DESCRIPTION
This PR adds comprehensive GitHub Gists functionality to GitHub Nexus:

## Features
- View, create, star, and delete Gists
- View Gist details with file content
- Add and delete comments on Gists
- Filter between your Gists, starred Gists, and public Gists
- Support for multi-file Gists
- Responsive UI consistent with the rest of the application

## Implementation
- Added Gist-related methods to GitHubService
- Created GistCard component for listing Gists
- Created GistViewer component for viewing Gist details
- Added CreateGistModal for creating new Gists
- Added navigation items in Sidebar and Header
- Created main Gists page and individual Gist view page

## Screenshots
[Screenshots can be added here]

This feature enhances GitHub Nexus by providing full Gist management capabilities, allowing users to create and share code snippets directly from the application.