### PR TITLE
Add GitHub Projects integration feature

### DIFF
--- a/app/components/layout/Header.tsx
+++ b/app/components/layout/Header.tsx
@@ -6,6 +6,19 @@ import { FC, useState, useRef, useEffect } from 'react';
 import { useAuth } from '../../hooks/useAuth';
 import NotificationBell from '../notifications/NotificationBell';
 import HeaderSearchBar from '../ui/HeaderSearchBar';
+import {
+  Navbar,
+  NavbarBrand,
+  NavbarContent,
+  NavbarItem,
+  Dropdown,
+  DropdownTrigger,
+  DropdownMenu,
+  DropdownItem,
+  Avatar,
+  Button
+} from "@nextui-org/react";
+import ThemeToggle from '../ui/ThemeToggle';
 
 const Header: FC = () => {
   const { session, isAuthenticated, isLoading, signIn, signOut } = useAuth();
@@ -27,120 +40,129 @@ const Header: FC = () => {
   }, []);
 
   return (
-    <header className="bg-gray-900 text-white shadow-md">
-      <div className="container mx-auto px-4 py-3 flex justify-between items-center">
-        <div className="flex items-center space-x-2">
-          <Link href="/" className="flex items-center space-x-2">
-            <div className="w-8 h-8 relative">
-              <Image
-                src="/logo.svg"
-                alt="GitHub Nexus Logo"
-                fill
-                className="object-contain"
-                priority
-              />
-            </div>
-            <span className="text-xl font-bold">GitHub Nexus</span>
-          </Link>
-        </div>
-
-        {isAuthenticated && (
-          <div className="flex items-center space-x-6">
-            <nav className="hidden md:flex items-center space-x-6">
-              <Link href="/repositories" className="hover:text-gray-300 transition-colors">
-                Repositories
-              </Link>
-              <Link href="/issues" className="hover:text-gray-300 transition-colors">
-                Issues
-              </Link>
-              <Link href="/pull-requests" className="hover:text-gray-300 transition-colors">
-                Pull Requests
-              </Link>
-              <Link href="/gists" className="hover:text-gray-300 transition-colors">
-                Gists
-              </Link>
-              <Link href="/code-review" className="hover:text-gray-300 transition-colors">
-                Code Review
-              </Link>
-              <Link href="/actions" className="hover:text-gray-300 transition-colors">
-                Actions
-              </Link>
-              <Link href="/insights" className="hover:text-gray-300 transition-colors">
-                Insights
-              </Link>
-            </nav>
-
-            <HeaderSearchBar className="hidden md:block" />
+    <Navbar
+      maxWidth="xl"
+      className="bg-background/70 dark:bg-background/70 backdrop-blur-md border-b border-divider"
+      classNames={{
+        wrapper: "px-4 sm:px-6",
+      }}
+    >
+      <NavbarBrand>
+        <Link href="/" className="flex items-center space-x-2">
+          <div className="w-8 h-8 relative">
+            <Image
+              src="/logo.svg"
+              alt="GitHub Nexus Logo"
+              fill
+              className="object-contain"
+              priority
+            />
           </div>
-        )}
+          <span className="text-xl font-bold">GitHub Nexus</span>
+        </Link>
+      </NavbarBrand>
 
-        <div className="flex items-center space-x-4">
-          {isAuthenticated ? (
-            <>
+      {isAuthenticated && (
+        <NavbarContent className="hidden md:flex gap-4" justify="center">
+          <NavbarItem>
+            <Link href="/repositories" className="text-foreground/80 hover:text-foreground transition-colors">
+              Repositories
+            </Link>
+          </NavbarItem>
+          <NavbarItem>
+            <Link href="/issues" className="text-foreground/80 hover:text-foreground transition-colors">
+              Issues
+            </Link>
+          </NavbarItem>
+          <NavbarItem>
+            <Link href="/pull-requests" className="text-foreground/80 hover:text-foreground transition-colors">
+              Pull Requests
+            </Link>
+          </NavbarItem>
+          <NavbarItem>
+            <Link href="/gists" className="text-foreground/80 hover:text-foreground transition-colors">
+              Gists
+            </Link>
+          </NavbarItem>
+          <NavbarItem>
+            <Link href="/code-review" className="text-foreground/80 hover:text-foreground transition-colors">
+              Code Review
+            </Link>
+          </NavbarItem>
+          <NavbarItem>
+            <Link href="/projects" className="text-foreground/80 hover:text-foreground transition-colors">
+              Projects
+            </Link>
+          </NavbarItem>
+          <NavbarItem>
+            <Link href="/actions" className="text-foreground/80 hover:text-foreground transition-colors">
+              Actions
+            </Link>
+          </NavbarItem>
+          <NavbarItem>
+            <Link href="/insights" className="text-foreground/80 hover:text-foreground transition-colors">
+              Insights
+            </Link>
+          </NavbarItem>
+          <NavbarItem>
+            <Link href="/team" className="text-foreground/80 hover:text-foreground transition-colors">
+              Team
+            </Link>
+          </NavbarItem>
+        </NavbarContent>
+      )}
+
+      <NavbarContent justify="end">
+        <NavbarItem>
+          <ThemeToggle />
+        </NavbarItem>
+
+        {isAuthenticated ? (
+          <>
+            <NavbarItem>
               <NotificationBell />
-              <div className="relative" ref={dropdownRef}>
-                <button
-                  onClick={() => setDropdownOpen(!dropdownOpen)}
-                  className="w-8 h-8 rounded-full overflow-hidden border-2 border-gray-700 focus:outline-none focus:border-blue-500"
-                >
-                  {session?.user?.image ? (
-                    <Image
-                      src={session.user.image}
-                      alt={session.user.name || "User"}
-                      width={32}
-                      height={32}
-                      className="object-cover"
-                    />
-                  ) : (
-                    <div className="w-full h-full bg-gray-500 flex items-center justify-center text-white">
-                      {session?.user?.name?.charAt(0) || "U"}
-                    </div>
-                  )}
-                </button>
-
-                {dropdownOpen && (
-                  <div className="absolute right-0 mt-2 w-48 bg-white dark:bg-gray-800 rounded-md shadow-lg py-1 z-50">
-                    <div className="px-4 py-2 border-b border-gray-200 dark:border-gray-700">
-                      <p className="text-sm font-medium text-gray-900 dark:text-white">{session?.user?.name}</p>
-                      <p className="text-xs text-gray-500 dark:text-gray-400 truncate">{session?.user?.email}</p>
-                    </div>
-                    <Link
-                      href="/profile"
-                      className="block px-4 py-2 text-sm text-gray-700 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-700"
-                      onClick={() => setDropdownOpen(false)}
-                    >
-                      Your Profile
-                    </Link>
-                    <Link
-                      href="/settings"
-                      className="block px-4 py-2 text-sm text-gray-700 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-700"
-                      onClick={() => setDropdownOpen(false)}
-                    >
-                      Settings
-                    </Link>
-                    <div className="border-t border-gray-200 dark:border-gray-700"></div>
-                    <Link
-                      href="/auth/signout"
-                      className="block px-4 py-2 text-sm text-gray-700 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-700"
-                      onClick={() => setDropdownOpen(false)}
-                    >
-                      Sign out
-                    </Link>
-                  </div>
-                )}
-              </div>
-            </>
-          ) : (
-            <Link
+            </NavbarItem>
+            <Dropdown placement="bottom-end">
+              <DropdownTrigger>
+                <Avatar
+                  as="button"
+                  className="transition-transform"
+                  src={session?.user?.image || undefined}
+                  name={session?.user?.name?.charAt(0) || "U"}
+                  size="sm"
+                />
+              </DropdownTrigger>
+              <DropdownMenu aria-label="User menu" variant="flat">
+                <DropdownItem key="profile" textValue="Profile" className="h-14 gap-2">
+                  <p className="font-semibold">{session?.user?.name}</p>
+                  <p className="text-xs text-default-500">{session?.user?.email}</p>
+                </DropdownItem>
+                <DropdownItem key="profile-page">
+                  <Link href="/profile" className="w-full">Your Profile</Link>
+                </DropdownItem>
+                <DropdownItem key="settings">
+                  <Link href="/settings" className="w-full">Settings</Link>
+                </DropdownItem>
+                <DropdownItem key="logout" color="danger">
+                  <Link href="/auth/signout" className="w-full">Sign out</Link>
+                </DropdownItem>
+              </DropdownMenu>
+            </Dropdown>
+          </>
+        ) : (
+          <NavbarItem>
+            <Button
+              as={Link}
               href="/auth/signin"
-              className="bg-blue-600 hover:bg-blue-700 text-white py-2 px-4 rounded-md text-sm font-medium transition-colors"
+              color="primary"
+              variant="flat"
             >
               Sign in
-            </Link>
-          )}
-        </div>
-      </div>
-    </header>
+            </Button>
+          </NavbarItem>
+        )}
+      </NavbarContent>
+    </Navbar>
   );
 };
 

--- a/app/components/layout/Sidebar.tsx
+++ b/app/components/layout/Sidebar.tsx
@@ -1,8 +1,16 @@
 "use client";
 
 import Link from 'next/link';
-import { FC } from 'react';
+import { FC, useEffect } from 'react';
 import { useAuth } from '../../hooks/useAuth';
+import { usePathname } from 'next/navigation';
+import {
+  Listbox,
+  ListboxItem,
+  Button,
+  Divider,
+  ScrollShadow
+} from "@nextui-org/react";
 
 interface SidebarProps {
   isOpen: boolean;
@@ -114,6 +122,19 @@ const Sidebar: FC<SidebarProps> = ({ isOpen, onClose }) => {
                       <path fillRule="evenodd" d="M18 13V5a2 2 0 00-2-2H4a2 2 0 00-2 2v8a2 2 0 002 2h3l3 3 3-3h3a2 2 0 002-2zM5 7a1 1 0 011-1h8a1 1 0 110 2H6a1 1 0 01-1-1zm1 3a1 1 0 100 2h3a1 1 0 100-2H6z" clipRule="evenodd" />
                     </svg>
                     <span>Code Review</span>
+                  </Link>
+                </li>
+                <li>
+                  <Link
+                    href="/projects"
+                    className="flex items-center space-x-2 p-2 rounded-md hover:bg-gray-700 transition-colors"
+                    onClick={() => onClose()}
+                  >
+                    <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5" viewBox="0 0 20 20" fill="currentColor">
+                      <path fillRule="evenodd" d="M5 3a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2V5a2 2 0 00-2-2H5zm0 2h10v10H5V5z" clipRule="evenodd" />
+                      <path d="M7 7h2v2H7V7zm0 4h2v2H7v-2zm4-4h2v2h-2V7zm0 4h2v2h-2v-2z" />
+                    </svg>
+                    <span>Projects</span>
                   </Link>
                 </li>
                 <li>

--- a/app/components/notifications/NotificationBell.tsx
+++ b/app/components/notifications/NotificationBell.tsx
@@ -5,6 +5,15 @@ import Link from 'next/link';
 import Image from 'next/image';
 import { useNotifications } from '../../context/NotificationsContext';
 import LoadingSpinner from '../ui/LoadingSpinner';
+import {
+  Popover,
+  PopoverTrigger,
+  PopoverContent,
+  Button,
+  Badge,
+  Spinner,
+  Divider
+} from "@nextui-org/react";
 
 interface NotificationBellProps {
   className?: string;
@@ -136,115 +145,141 @@ const NotificationBell: FC<NotificationBellProps> = ({ className = "" }) => {
   }, [isOpen]);
 
   return (
-    <div className={`relative ${className}`} ref={dropdownRef}>
-      <button
-        onClick={() => setIsOpen(!isOpen)}
-        className="p-2 rounded-full hover:bg-gray-200 dark:hover:bg-gray-700 transition-colors relative"
-        aria-label="Notifications"
-        title="Notifications"
-      >
-        <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5" viewBox="0 0 20 20" fill="currentColor">
-          <path d="M10 2a6 6 0 00-6 6v3.586l-.707.707A1 1 0 004 14h12a1 1 0 00.707-1.707L16 11.586V8a6 6 0 00-6-6zM10 18a3 3 0 01-3-3h6a3 3 0 01-3 3z" />
-        </svg>
-
-        {unreadCount > 0 && (
-          <span className="absolute top-0 right-0 inline-flex items-center justify-center px-2 py-1 text-xs font-bold leading-none text-white transform translate-x-1/2 -translate-y-1/2 bg-red-500 rounded-full">
-            {unreadCount > 99 ? '99+' : unreadCount}
-          </span>
-        )}
-      </button>
-
-      {isOpen && (
-        <div className="absolute right-0 mt-2 w-80 bg-white dark:bg-gray-800 rounded-md shadow-lg z-50 overflow-hidden">
-          <div className="border-b border-gray-200 dark:border-gray-700 px-4 py-3 flex justify-between items-center">
-            <h3 className="font-medium">Notifications</h3>
-            <div className="flex items-center space-x-2">
-              <button
-                onClick={handleRefresh}
-                className="text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300"
-                disabled={localLoading || isLoading}
-                title="Refresh notifications"
-              >
-                <svg xmlns="http://www.w3.org/2000/svg" className={`h-4 w-4 ${(localLoading || isLoading) ? 'animate-spin' : ''}`} viewBox="0 0 20 20" fill="currentColor">
-                  <path fillRule="evenodd" d="M4 2a1 1 0 011 1v2.101a7.002 7.002 0 0111.601 2.566 1 1 0 11-1.885.666A5.002 5.002 0 005.999 7H9a1 1 0 010 2H4a1 1 0 01-1-1V3a1 1 0 011-1zm.008 9.057a1 1 0 011.276.61A5.002 5.002 0 0014.001 13H11a1 1 0 110-2h5a1 1 0 011 1v5a1 1 0 11-2 0v-2.101a7.002 7.002 0 01-11.601-2.566 1 1 0 01.61-1.276z" clipRule="evenodd" />
-                </svg>
-              </button>
-              <Link
-                href="/notifications"
-                className="text-sm text-blue-600 dark:text-blue-400 hover:underline"
-                onClick={() => setIsOpen(false)}
-              >
-                See all
-              </Link>
-            </div>
-          </div>
-
-          <div className="max-h-96 overflow-y-auto">
-            {(isLoading || localLoading) ? (
-              <div className="flex justify-center items-center py-8">
-                <LoadingSpinner size="small" />
-              </div>
-            ) : error ? (
-              <div className="py-8 text-center">
-                <p className="text-red-500 dark:text-red-400 mb-2">{error}</p>
-                <button
-                  onClick={handleRefresh}
-                  className="text-sm text-blue-600 dark:text-blue-400 hover:underline"
-                >
-                  Try again
-                </button>
-              </div>
-            ) : notifications.length > 0 ? (
-              <div>
-                {notifications.slice(0, 5).map(notification => (
-                  <Link
-                    key={notification.id}
-                    href={getNotificationUrl(notification)}
-                    onClick={() => handleNotificationClick(notification)}
-                    className={`block px-4 py-3 hover:bg-gray-100 dark:hover:bg-gray-700 border-b border-gray-200 dark:border-gray-700 last:border-0 ${
-                      notification.unread ? 'bg-blue-50 dark:bg-blue-900/20' : ''
-                    }`}
-                  >
-                    <div className="flex items-start">
-                      <div className="flex-shrink-0 mr-3">
-                        {getNotificationIcon(notification.subject.type)}
-                      </div>
-                      <div className="flex-1 min-w-0">
-                        <p className="text-sm font-medium text-gray-900 dark:text-white truncate">
-                          {notification.subject.title}
-                        </p>
-                        <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">
-                          {notification.repository.full_name} • {formatTime(notification.updated_at)}
-                        </p>
-                      </div>
-                      {notification.unread && (
-                        <div className="ml-2 flex-shrink-0">
-                          <span className="inline-block w-2 h-2 bg-blue-500 rounded-full"></span>
-                        </div>
-                      )}
-                    </div>
-                  </Link>
-                ))}
-              </div>
-            ) : (
-              <div className="py-8 text-center text-gray-500 dark:text-gray-400">
-                <p>No notifications</p>
-              </div>
-            )}
-          </div>
-
-          <div className="border-t border-gray-200 dark:border-gray-700 px-4 py-2">
-            <Link
-              href="/settings/notifications"
-              className="text-xs text-gray-500 dark:text-gray-400 hover:underline block text-center"
+    <Popover
+      placement="bottom-end"
+      isOpen={isOpen}
+      onOpenChange={setIsOpen}
+      classNames={{
+        content: "p-0 glass"
+      }}
+    >
+      <PopoverTrigger>
+        <div className={className}>
+          <Badge
+            content={unreadCount > 99 ? '99+' : unreadCount}
+            color="danger"
+            isInvisible={unreadCount === 0}
+            shape="circle"
+            size="sm"
+          >
+            <Button
+              isIconOnly
+              variant="light"
+              aria-label="Notifications"
+              title="Notifications"
+              radius="full"
+              onClick={() => setIsOpen(!isOpen)}
+            >
+              <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5" viewBox="0 0 20 20" fill="currentColor">
+                <path d="M10 2a6 6 0 00-6 6v3.586l-.707.707A1 1 0 004 14h12a1 1 0 00.707-1.707L16 11.586V8a6 6 0 00-6-6zM10 18a3 3 0 01-3-3h6a3 3 0 01-3 3z" />
+              </svg>
+            </Button>
+          </Badge>
+        </div>
+      </PopoverTrigger>
+      <PopoverContent className="w-80">
+        <div className="px-4 py-3 flex justify-between items-center">
+          <h3 className="text-medium font-medium">Notifications</h3>
+          <div className="flex items-center gap-2">
+            <Button
+              isIconOnly
+              size="sm"
+              variant="light"
+              onClick={handleRefresh}
+              isLoading={localLoading || isLoading}
+              title="Refresh notifications"
+            >
+              <svg xmlns="http://www.w3.org/2000/svg" className="h-4 w-4" viewBox="0 0 20 20" fill="currentColor">
+                <path fillRule="evenodd" d="M4 2a1 1 0 011 1v2.101a7.002 7.002 0 0111.601 2.566 1 1 0 11-1.885.666A5.002 5.002 0 005.999 7H9a1 1 0 010 2H4a1 1 0 01-1-1V3a1 1 0 011-1zm.008 9.057a1 1 0 011.276.61A5.002 5.002 0 0014.001 13H11a1 1 0 110-2h5a1 1 0 011 1v5a1 1 0 11-2 0v-2.101a7.002 7.002 0 01-11.601-2.566 1 1 0 01.61-1.276z" clipRule="evenodd" />
+              </svg>
+            </Button>
+            <Button
+              as={Link}
+              href="/notifications"
+              size="sm"
+              variant="light"
+              color="primary"
               onClick={() => setIsOpen(false)}
             >
-              Notification settings
-            </Link>
+              See all
+            </Button>
           </div>
         </div>
-      )}
-    </div>
+
+        <Divider />
+
+        <div className="max-h-96 overflow-y-auto">
+          {(isLoading || localLoading) ? (
+            <div className="flex justify-center items-center py-8">
+              <Spinner size="sm" />
+            </div>
+          ) : error ? (
+            <div className="py-8 text-center">
+              <p className="text-danger mb-2">{error}</p>
+              <Button
+                size="sm"
+                variant="flat"
+                color="primary"
+                onClick={handleRefresh}
+              >
+                Try again
+              </Button>
+            </div>
+          ) : notifications.length > 0 ? (
+            <div>
+              {notifications.slice(0, 5).map(notification => (
+                <Link
+                  key={notification.id}
+                  href={getNotificationUrl(notification)}
+                  onClick={() => handleNotificationClick(notification)}
+                  className={`block px-4 py-3 hover:bg-default-100 dark:hover:bg-default-50/10 ${
+                    notification.unread ? 'bg-primary-50/30 dark:bg-primary-900/20' : ''
+                  }`}
+                >
+                  <div className="flex items-start">
+                    <div className="flex-shrink-0 mr-3">
+                      {getNotificationIcon(notification.subject.type)}
+                    </div>
+                    <div className="flex-1 min-w-0">
+                      <p className="text-sm font-medium truncate">
+                        {notification.subject.title}
+                      </p>
+                      <p className="text-xs text-default-500 mt-1">
+                        {notification.repository.full_name} • {formatTime(notification.updated_at)}
+                      </p>
+                    </div>
+                    {notification.unread && (
+                      <div className="ml-2 flex-shrink-0">
+                        <span className="inline-block w-2 h-2 bg-primary rounded-full"></span>
+                      </div>
+                    )}
+                  </div>
+                </Link>
+              ))}
+            </div>
+          ) : (
+            <div className="py-8 text-center text-default-500">
+              <p>No notifications</p>
+            </div>
+          )}
+        </div>
+
+        <Divider />
+
+        <div className="px-4 py-2">
+          <Button
+            as={Link}
+            href="/settings/notifications"
+            size="sm"
+            variant="light"
+            className="w-full"
+            onClick={() => setIsOpen(false)}
+          >
+            Notification settings
+          </Button>
+        </div>
+      </PopoverContent>
+    </Popover>
   );
 };
 

--- a/app/components/projects/CreateColumnModal.tsx
+++ b/app/components/projects/CreateColumnModal.tsx
@@ -1,0 +1,105 @@
+"use client";
+
+import { useState } from "react";
+import { useGitHub } from "../../context/GitHubContext";
+
+interface CreateColumnModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  projectId: number;
+  onColumnCreated: (column: any) => void;
+}
+
+export default function CreateColumnModal({
+  isOpen,
+  onClose,
+  projectId,
+  onColumnCreated,
+}: CreateColumnModalProps) {
+  const { githubService } = useGitHub();
+  const [name, setName] = useState("");
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    
+    if (!githubService || !name.trim()) return;
+    
+    try {
+      setIsLoading(true);
+      setError(null);
+      
+      const column = await githubService.createProjectColumn(projectId, name);
+      onColumnCreated(column);
+      setName("");
+      onClose();
+    } catch (err) {
+      console.error("Error creating column:", err);
+      setError("Failed to create column. Please try again.");
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  if (!isOpen) return null;
+
+  return (
+    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4">
+      <div className="bg-white dark:bg-gray-800 rounded-lg shadow-xl w-full max-w-md">
+        <div className="p-4 border-b border-gray-200 dark:border-gray-700 flex justify-between items-center">
+          <h2 className="text-xl font-semibold">Add New Column</h2>
+          <button
+            onClick={onClose}
+            className="text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200"
+          >
+            <svg xmlns="http://www.w3.org/2000/svg" className="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
+        </div>
+        
+        <form onSubmit={handleSubmit} className="p-4">
+          {error && (
+            <div className="mb-4 p-3 bg-red-100 dark:bg-red-900 text-red-800 dark:text-red-200 rounded-md">
+              {error}
+            </div>
+          )}
+          
+          <div className="mb-4">
+            <label htmlFor="name" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+              Column Name
+            </label>
+            <input
+              type="text"
+              id="name"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500 dark:bg-gray-700 dark:text-white"
+              placeholder="Enter column name (e.g., To Do, In Progress, Done)"
+              required
+              autoFocus
+            />
+          </div>
+          
+          <div className="flex justify-end space-x-3 mt-6">
+            <button
+              type="button"
+              onClick={onClose}
+              className="px-4 py-2 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm text-sm font-medium text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-700 hover:bg-gray-50 dark:hover:bg-gray-600 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500"
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              disabled={isLoading || !name.trim()}
+              className="px-4 py-2 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              {isLoading ? "Creating..." : "Create Column"}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/app/components/projects/CreateProjectModal.tsx
+++ b/app/components/projects/CreateProjectModal.tsx
@@ -1,0 +1,298 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { useGitHub } from "../../context/GitHubContext";
+
+interface CreateProjectModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onProjectCreated: (project: any) => void;
+}
+
+interface Repository {
+  id: number;
+  name: string;
+  full_name: string;
+  owner: {
+    login: string;
+  };
+}
+
+interface Organization {
+  login: string;
+  avatar_url: string;
+}
+
+export default function CreateProjectModal({
+  isOpen,
+  onClose,
+  onProjectCreated,
+}: CreateProjectModalProps) {
+  const { githubService } = useGitHub();
+  const [name, setName] = useState("");
+  const [body, setBody] = useState("");
+  const [projectType, setProjectType] = useState<"user" | "repository" | "organization">("user");
+  const [repositories, setRepositories] = useState<Repository[]>([]);
+  const [organizations, setOrganizations] = useState<Organization[]>([]);
+  const [selectedRepo, setSelectedRepo] = useState<string>("");
+  const [selectedOrg, setSelectedOrg] = useState<string>("");
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    async function fetchData() {
+      if (!githubService) return;
+      
+      try {
+        setIsLoading(true);
+        
+        // Fetch repositories and organizations in parallel
+        const [reposData, orgsData] = await Promise.all([
+          githubService.getUserRepositories(),
+          githubService.getUserOrganizations(),
+        ]);
+        
+        setRepositories(reposData);
+        setOrganizations(orgsData);
+        
+        // Set default selections if available
+        if (reposData.length > 0) {
+          setSelectedRepo(reposData[0].full_name);
+        }
+        
+        if (orgsData.length > 0) {
+          setSelectedOrg(orgsData[0].login);
+        }
+      } catch (err) {
+        console.error("Error fetching data:", err);
+        setError("Failed to load repositories and organizations. Please try again.");
+      } finally {
+        setIsLoading(false);
+      }
+    }
+    
+    if (isOpen) {
+      fetchData();
+    }
+  }, [githubService, isOpen]);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    
+    if (!githubService || !name.trim()) return;
+    
+    try {
+      setIsLoading(true);
+      setError(null);
+      
+      let project;
+      
+      if (projectType === "user") {
+        // Create user project
+        project = await githubService.createProject({
+          owner: "",
+          name,
+          body,
+        });
+      } else if (projectType === "repository" && selectedRepo) {
+        // Create repository project
+        const [owner, repo] = selectedRepo.split("/");
+        project = await githubService.createProject({
+          owner,
+          repo,
+          name,
+          body,
+        });
+      } else if (projectType === "organization" && selectedOrg) {
+        // Create organization project
+        project = await githubService.createProject({
+          owner: "",
+          org: selectedOrg,
+          name,
+          body,
+        });
+      } else {
+        setError("Invalid project type or selection");
+        setIsLoading(false);
+        return;
+      }
+      
+      onProjectCreated(project);
+      resetForm();
+      onClose();
+    } catch (err) {
+      console.error("Error creating project:", err);
+      setError("Failed to create project. Please try again.");
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const resetForm = () => {
+    setName("");
+    setBody("");
+    setProjectType("user");
+    setSelectedRepo(repositories.length > 0 ? repositories[0].full_name : "");
+    setSelectedOrg(organizations.length > 0 ? organizations[0].login : "");
+    setError(null);
+  };
+
+  if (!isOpen) return null;
+
+  return (
+    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4">
+      <div className="bg-white dark:bg-gray-800 rounded-lg shadow-xl w-full max-w-md max-h-[90vh] overflow-y-auto">
+        <div className="p-4 border-b border-gray-200 dark:border-gray-700 flex justify-between items-center">
+          <h2 className="text-xl font-semibold">Create New Project</h2>
+          <button
+            onClick={onClose}
+            className="text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200"
+          >
+            <svg xmlns="http://www.w3.org/2000/svg" className="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
+        </div>
+        
+        <form onSubmit={handleSubmit} className="p-4">
+          {error && (
+            <div className="mb-4 p-3 bg-red-100 dark:bg-red-900 text-red-800 dark:text-red-200 rounded-md">
+              {error}
+            </div>
+          )}
+          
+          <div className="mb-4">
+            <label htmlFor="project-type" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+              Project Type
+            </label>
+            <div className="flex flex-wrap gap-4">
+              <label className="inline-flex items-center">
+                <input
+                  type="radio"
+                  className="form-radio text-blue-600"
+                  name="project-type"
+                  value="user"
+                  checked={projectType === "user"}
+                  onChange={() => setProjectType("user")}
+                />
+                <span className="ml-2">User Project</span>
+              </label>
+              <label className="inline-flex items-center">
+                <input
+                  type="radio"
+                  className="form-radio text-blue-600"
+                  name="project-type"
+                  value="repository"
+                  checked={projectType === "repository"}
+                  onChange={() => setProjectType("repository")}
+                  disabled={repositories.length === 0}
+                />
+                <span className="ml-2">Repository Project</span>
+              </label>
+              <label className="inline-flex items-center">
+                <input
+                  type="radio"
+                  className="form-radio text-blue-600"
+                  name="project-type"
+                  value="organization"
+                  checked={projectType === "organization"}
+                  onChange={() => setProjectType("organization")}
+                  disabled={organizations.length === 0}
+                />
+                <span className="ml-2">Organization Project</span>
+              </label>
+            </div>
+          </div>
+          
+          {projectType === "repository" && (
+            <div className="mb-4">
+              <label htmlFor="repository" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                Repository
+              </label>
+              <select
+                id="repository"
+                value={selectedRepo}
+                onChange={(e) => setSelectedRepo(e.target.value)}
+                className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500 dark:bg-gray-700 dark:text-white"
+                required
+              >
+                {repositories.map((repo) => (
+                  <option key={repo.id} value={repo.full_name}>
+                    {repo.full_name}
+                  </option>
+                ))}
+              </select>
+            </div>
+          )}
+          
+          {projectType === "organization" && (
+            <div className="mb-4">
+              <label htmlFor="organization" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                Organization
+              </label>
+              <select
+                id="organization"
+                value={selectedOrg}
+                onChange={(e) => setSelectedOrg(e.target.value)}
+                className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500 dark:bg-gray-700 dark:text-white"
+                required
+              >
+                {organizations.map((org) => (
+                  <option key={org.login} value={org.login}>
+                    {org.login}
+                  </option>
+                ))}
+              </select>
+            </div>
+          )}
+          
+          <div className="mb-4">
+            <label htmlFor="name" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+              Project Name
+            </label>
+            <input
+              type="text"
+              id="name"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500 dark:bg-gray-700 dark:text-white"
+              placeholder="Enter project name"
+              required
+            />
+          </div>
+          
+          <div className="mb-4">
+            <label htmlFor="body" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+              Description (optional)
+            </label>
+            <textarea
+              id="body"
+              value={body}
+              onChange={(e) => setBody(e.target.value)}
+              className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500 dark:bg-gray-700 dark:text-white"
+              placeholder="Enter project description"
+              rows={4}
+            />
+          </div>
+          
+          <div className="flex justify-end space-x-3 mt-6">
+            <button
+              type="button"
+              onClick={onClose}
+              className="px-4 py-2 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm text-sm font-medium text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-700 hover:bg-gray-50 dark:hover:bg-gray-600 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500"
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              disabled={isLoading || !name.trim()}
+              className="px-4 py-2 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              {isLoading ? "Creating..." : "Create Project"}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/app/components/projects/ProjectCard.tsx
+++ b/app/components/projects/ProjectCard.tsx
@@ -1,0 +1,153 @@
+"use client";
+
+import Link from "next/link";
+import { useState } from "react";
+import { useGitHub } from "../../context/GitHubContext";
+
+interface ProjectCardProps {
+  project: {
+    id: number;
+    name: string;
+    body: string;
+    html_url: string;
+    created_at: string;
+    updated_at: string;
+    creator: {
+      login: string;
+      avatar_url: string;
+    };
+    state: string;
+    number_of_columns?: number;
+    owner_url?: string;
+  };
+  onDelete?: (projectId: number) => void;
+}
+
+export default function ProjectCard({ project, onDelete }: ProjectCardProps) {
+  const { githubService } = useGitHub();
+  const [isLoading, setIsLoading] = useState(false);
+  const [columns, setColumns] = useState<number | null>(project.number_of_columns || null);
+
+  // Format date
+  const formatDate = (dateString: string) => {
+    const date = new Date(dateString);
+    return date.toLocaleDateString("en-US", {
+      year: "numeric",
+      month: "short",
+      day: "numeric",
+    });
+  };
+
+  // Fetch columns count if not provided
+  const fetchColumnsCount = async () => {
+    if (columns !== null || !githubService) return;
+    
+    try {
+      setIsLoading(true);
+      const projectColumns = await githubService.getProjectColumns(project.id);
+      setColumns(projectColumns.length);
+    } catch (error) {
+      console.error("Error fetching project columns:", error);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  // Handle delete
+  const handleDelete = async () => {
+    if (!githubService || !onDelete) return;
+    
+    if (window.confirm(`Are you sure you want to delete the project "${project.name}"?`)) {
+      try {
+        setIsLoading(true);
+        await githubService.deleteProject(project.id);
+        onDelete(project.id);
+      } catch (error) {
+        console.error("Error deleting project:", error);
+        alert("Failed to delete project. Please try again.");
+      } finally {
+        setIsLoading(false);
+      }
+    }
+  };
+
+  return (
+    <div 
+      className="bg-white dark:bg-gray-800 rounded-lg shadow-md overflow-hidden hover:shadow-lg transition-shadow"
+      onMouseEnter={fetchColumnsCount}
+    >
+      <div className="p-4 border-b border-gray-200 dark:border-gray-700">
+        <div className="flex justify-between items-start mb-2">
+          <Link href={`/projects/${project.id}`} className="text-lg font-semibold text-blue-600 dark:text-blue-400 hover:underline">
+            {project.name}
+          </Link>
+          <div className="flex space-x-2">
+            {onDelete && (
+              <button
+                onClick={handleDelete}
+                disabled={isLoading}
+                className="text-gray-500 dark:text-gray-400 hover:text-red-500 dark:hover:text-red-400"
+                title="Delete this project"
+              >
+                <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5" viewBox="0 0 20 20" fill="none" stroke="currentColor">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+                </svg>
+              </button>
+            )}
+            <a
+              href={project.html_url}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-gray-500 dark:text-gray-400 hover:text-blue-500 dark:hover:text-blue-400"
+              title="View on GitHub"
+            >
+              <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5" viewBox="0 0 20 20" fill="currentColor">
+                <path d="M11 3a1 1 0 100 2h2.586l-6.293 6.293a1 1 0 101.414 1.414L15 6.414V9a1 1 0 102 0V4a1 1 0 00-1-1h-5z" />
+                <path d="M5 5a2 2 0 00-2 2v8a2 2 0 002 2h8a2 2 0 002-2v-3a1 1 0 10-2 0v3H5V7h3a1 1 0 000-2H5z" />
+              </svg>
+            </a>
+          </div>
+        </div>
+        <div className="flex items-center text-sm text-gray-600 dark:text-gray-400 mb-2">
+          {project.creator && (
+            <>
+              <img src={project.creator.avatar_url} alt={project.creator.login} className="w-5 h-5 rounded-full mr-2" />
+              <span>{project.creator.login}</span>
+              <span className="mx-2">•</span>
+            </>
+          )}
+          <span>Created: {formatDate(project.created_at)}</span>
+          {project.updated_at !== project.created_at && (
+            <>
+              <span className="mx-2">•</span>
+              <span>Updated: {formatDate(project.updated_at)}</span>
+            </>
+          )}
+        </div>
+        <div className="flex items-center text-xs text-gray-500 dark:text-gray-500">
+          <span className={`px-2 py-1 rounded ${
+            project.state === "open" 
+              ? "bg-green-100 dark:bg-green-900 text-green-800 dark:text-green-200" 
+              : "bg-red-100 dark:bg-red-900 text-red-800 dark:text-red-200"
+          }`}>
+            {project.state}
+          </span>
+          {columns !== null && (
+            <span className="ml-2">{columns} {columns === 1 ? "column" : "columns"}</span>
+          )}
+        </div>
+      </div>
+      <div className="p-4 bg-gray-50 dark:bg-gray-900">
+        {project.body ? (
+          <p className="text-sm text-gray-700 dark:text-gray-300 line-clamp-3">
+            {project.body}
+          </p>
+        ) : (
+          <p className="text-sm text-gray-500 dark:text-gray-500 italic">
+            No description provided.
+          </p>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/app/components/projects/ProjectColumn.tsx
+++ b/app/components/projects/ProjectColumn.tsx
@@ -1,0 +1,258 @@
+"use client";
+
+import { useState } from "react";
+import { useGitHub } from "../../context/GitHubContext";
+import ProjectCard from "./ProjectCard";
+
+interface ProjectColumnProps {
+  column: {
+    id: number;
+    name: string;
+    created_at: string;
+    updated_at: string;
+    project_url: string;
+  };
+  cards: Array<{
+    id: number;
+    note: string;
+    created_at: string;
+    updated_at: string;
+    column_url: string;
+    content_url?: string;
+    creator?: {
+      login: string;
+      avatar_url: string;
+    };
+  }>;
+  onDeleteColumn: (columnId: number) => void;
+  onUpdateColumn: (columnId: number, name: string) => void;
+  onAddCard: (columnId: number) => void;
+  onDeleteCard: (cardId: number) => void;
+  onMoveCard: (cardId: number, columnId: number, position: string) => void;
+}
+
+export default function ProjectColumn({
+  column,
+  cards,
+  onDeleteColumn,
+  onUpdateColumn,
+  onAddCard,
+  onDeleteCard,
+  onMoveCard,
+}: ProjectColumnProps) {
+  const { githubService } = useGitHub();
+  const [isEditing, setIsEditing] = useState(false);
+  const [columnName, setColumnName] = useState(column.name);
+  const [isLoading, setIsLoading] = useState(false);
+  const [showAddCard, setShowAddCard] = useState(false);
+  const [newCardNote, setNewCardNote] = useState("");
+
+  // Handle column name update
+  const handleUpdateColumn = async () => {
+    if (!githubService || !columnName.trim()) return;
+    
+    try {
+      setIsLoading(true);
+      await githubService.updateProjectColumn(column.id, columnName);
+      onUpdateColumn(column.id, columnName);
+      setIsEditing(false);
+    } catch (error) {
+      console.error("Error updating column:", error);
+      alert("Failed to update column. Please try again.");
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  // Handle column deletion
+  const handleDeleteColumn = async () => {
+    if (!githubService) return;
+    
+    if (window.confirm(`Are you sure you want to delete the column "${column.name}"?`)) {
+      try {
+        setIsLoading(true);
+        await githubService.deleteProjectColumn(column.id);
+        onDeleteColumn(column.id);
+      } catch (error) {
+        console.error("Error deleting column:", error);
+        alert("Failed to delete column. Please try again.");
+      } finally {
+        setIsLoading(false);
+      }
+    }
+  };
+
+  // Handle card creation
+  const handleAddCard = async () => {
+    if (!githubService || !newCardNote.trim()) return;
+    
+    try {
+      setIsLoading(true);
+      await githubService.createCard(column.id, { note: newCardNote });
+      onAddCard(column.id);
+      setNewCardNote("");
+      setShowAddCard(false);
+    } catch (error) {
+      console.error("Error creating card:", error);
+      alert("Failed to create card. Please try again.");
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  // Handle card deletion
+  const handleDeleteCard = async (cardId: number) => {
+    if (!githubService) return;
+    
+    if (window.confirm("Are you sure you want to delete this card?")) {
+      try {
+        setIsLoading(true);
+        await githubService.deleteCard(cardId);
+        onDeleteCard(cardId);
+      } catch (error) {
+        console.error("Error deleting card:", error);
+        alert("Failed to delete card. Please try again.");
+      } finally {
+        setIsLoading(false);
+      }
+    }
+  };
+
+  return (
+    <div className="bg-gray-100 dark:bg-gray-800 rounded-lg shadow-md w-80 flex-shrink-0">
+      <div className="p-3 bg-gray-200 dark:bg-gray-700 rounded-t-lg flex justify-between items-center">
+        {isEditing ? (
+          <div className="flex-1">
+            <input
+              type="text"
+              value={columnName}
+              onChange={(e) => setColumnName(e.target.value)}
+              className="w-full px-2 py-1 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500 dark:bg-gray-800 dark:text-white text-sm"
+              placeholder="Column name"
+              autoFocus
+            />
+            <div className="flex mt-1 space-x-2">
+              <button
+                onClick={handleUpdateColumn}
+                disabled={isLoading || !columnName.trim()}
+                className="text-xs bg-blue-600 text-white px-2 py-1 rounded-md hover:bg-blue-700 disabled:opacity-50"
+              >
+                Save
+              </button>
+              <button
+                onClick={() => {
+                  setColumnName(column.name);
+                  setIsEditing(false);
+                }}
+                className="text-xs bg-gray-500 text-white px-2 py-1 rounded-md hover:bg-gray-600"
+              >
+                Cancel
+              </button>
+            </div>
+          </div>
+        ) : (
+          <h3 className="font-medium text-gray-800 dark:text-white">{column.name}</h3>
+        )}
+        {!isEditing && (
+          <div className="flex space-x-1">
+            <button
+              onClick={() => setIsEditing(true)}
+              className="text-gray-600 dark:text-gray-300 hover:text-blue-600 dark:hover:text-blue-400"
+              title="Edit column"
+            >
+              <svg xmlns="http://www.w3.org/2000/svg" className="h-4 w-4" viewBox="0 0 20 20" fill="currentColor">
+                <path d="M13.586 3.586a2 2 0 112.828 2.828l-.793.793-2.828-2.828.793-.793zM11.379 5.793L3 14.172V17h2.828l8.38-8.379-2.83-2.828z" />
+              </svg>
+            </button>
+            <button
+              onClick={handleDeleteColumn}
+              disabled={isLoading}
+              className="text-gray-600 dark:text-gray-300 hover:text-red-600 dark:hover:text-red-400"
+              title="Delete column"
+            >
+              <svg xmlns="http://www.w3.org/2000/svg" className="h-4 w-4" viewBox="0 0 20 20" fill="currentColor">
+                <path fillRule="evenodd" d="M9 2a1 1 0 00-.894.553L7.382 4H4a1 1 0 000 2v10a2 2 0 002 2h8a2 2 0 002-2V6a1 1 0 100-2h-3.382l-.724-1.447A1 1 0 0011 2H9zM7 8a1 1 0 012 0v6a1 1 0 11-2 0V8zm5-1a1 1 0 00-1 1v6a1 1 0 102 0V8a1 1 0 00-1-1z" clipRule="evenodd" />
+              </svg>
+            </button>
+          </div>
+        )}
+      </div>
+      
+      <div className="p-2 max-h-[calc(100vh-200px)] overflow-y-auto">
+        {cards.length > 0 ? (
+          <div className="space-y-2">
+            {cards.map((card) => (
+              <div key={card.id} className="bg-white dark:bg-gray-900 rounded-md shadow-sm p-3">
+                <div className="flex justify-between items-start mb-2">
+                  <div className="text-sm text-gray-800 dark:text-gray-200 whitespace-pre-wrap">
+                    {card.note}
+                  </div>
+                  <button
+                    onClick={() => handleDeleteCard(card.id)}
+                    className="text-gray-400 hover:text-red-500 dark:hover:text-red-400 ml-2"
+                    title="Delete card"
+                  >
+                    <svg xmlns="http://www.w3.org/2000/svg" className="h-4 w-4" viewBox="0 0 20 20" fill="currentColor">
+                      <path fillRule="evenodd" d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z" clipRule="evenodd" />
+                    </svg>
+                  </button>
+                </div>
+                {card.creator && (
+                  <div className="flex items-center text-xs text-gray-500 dark:text-gray-400">
+                    <img src={card.creator.avatar_url} alt={card.creator.login} className="w-4 h-4 rounded-full mr-1" />
+                    <span>{card.creator.login}</span>
+                  </div>
+                )}
+              </div>
+            ))}
+          </div>
+        ) : (
+          <div className="text-center py-4 text-gray-500 dark:text-gray-400 text-sm">
+            No cards in this column
+          </div>
+        )}
+        
+        {showAddCard ? (
+          <div className="mt-2 bg-white dark:bg-gray-900 rounded-md shadow-sm p-3">
+            <textarea
+              value={newCardNote}
+              onChange={(e) => setNewCardNote(e.target.value)}
+              className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500 dark:bg-gray-800 dark:text-white text-sm"
+              placeholder="Enter card content..."
+              rows={3}
+              autoFocus
+            />
+            <div className="flex justify-end mt-2 space-x-2">
+              <button
+                onClick={() => {
+                  setNewCardNote("");
+                  setShowAddCard(false);
+                }}
+                className="text-xs bg-gray-500 text-white px-2 py-1 rounded-md hover:bg-gray-600"
+              >
+                Cancel
+              </button>
+              <button
+                onClick={handleAddCard}
+                disabled={isLoading || !newCardNote.trim()}
+                className="text-xs bg-blue-600 text-white px-2 py-1 rounded-md hover:bg-blue-700 disabled:opacity-50"
+              >
+                Add
+              </button>
+            </div>
+          </div>
+        ) : (
+          <button
+            onClick={() => setShowAddCard(true)}
+            className="w-full mt-2 flex items-center justify-center py-2 text-sm text-gray-600 dark:text-gray-400 hover:bg-gray-200 dark:hover:bg-gray-700 rounded-md transition-colors"
+          >
+            <svg xmlns="http://www.w3.org/2000/svg" className="h-4 w-4 mr-1" viewBox="0 0 20 20" fill="currentColor">
+              <path fillRule="evenodd" d="M10 5a1 1 0 011 1v3h3a1 1 0 110 2h-3v3a1 1 0 11-2 0v-3H6a1 1 0 110-2h3V6a1 1 0 011-1z" clipRule="evenodd" />
+            </svg>
+            Add card
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/app/components/ui/ThemeToggle.tsx
+++ b/app/components/ui/ThemeToggle.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import { useTheme } from "../../context/ThemeContext";
+import { Button } from "@nextui-org/react";
+import { FC } from "react";
+
+interface ThemeToggleProps {
+  className?: string;
+}
+
+const ThemeToggle: FC<ThemeToggleProps> = ({ className }) => {
+  const { theme, toggleTheme } = useTheme();
+
+  return (
+    <Button
+      isIconOnly
+      variant="light"
+      aria-label="Toggle theme"
+      onClick={toggleTheme}
+      className={className}
+    >
+      {theme === "light" ? (
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          className="w-5 h-5"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+            d="M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z"
+          />
+        </svg>
+      ) : (
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          className="w-5 h-5"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+            d="M12 3v1m0 16v1m9-9h-1M4 12H3m15.364 6.364l-.707-.707M6.343 6.343l-.707-.707m12.728 0l-.707.707M6.343 17.657l-.707.707M16 12a4 4 0 11-8 0 4 4 0 018 0z"
+          />
+        </svg>
+      )}
+    </Button>
+  );
+};
+
+export default ThemeToggle;

--- a/app/context/ThemeContext.tsx
+++ b/app/context/ThemeContext.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import React, { createContext, useContext, useEffect, useState } from "react";
+
+type Theme = "light" | "dark";
+
+interface ThemeContextType {
+  theme: Theme;
+  toggleTheme: () => void;
+  setTheme: (theme: Theme) => void;
+}
+
+const ThemeContext = createContext<ThemeContextType | undefined>(undefined);
+
+export function ThemeProvider({ children }: { children: React.ReactNode }) {
+  const [theme, setTheme] = useState<Theme>("light");
+
+  // Initialize theme from localStorage or system preference
+  useEffect(() => {
+    const storedTheme = localStorage.getItem("theme") as Theme | null;
+    
+    if (storedTheme) {
+      setTheme(storedTheme);
+      document.documentElement.classList.remove("light", "dark");
+      document.documentElement.classList.add(storedTheme);
+    } else if (window.matchMedia("(prefers-color-scheme: dark)").matches) {
+      setTheme("dark");
+      document.documentElement.classList.remove("light");
+      document.documentElement.classList.add("dark");
+    }
+  }, []);
+
+  // Update HTML class when theme changes
+  useEffect(() => {
+    document.documentElement.classList.remove("light", "dark");
+    document.documentElement.classList.add(theme);
+    localStorage.setItem("theme", theme);
+  }, [theme]);
+
+  const toggleTheme = () => {
+    setTheme(prevTheme => (prevTheme === "light" ? "dark" : "light"));
+  };
+
+  return (
+    <ThemeContext.Provider value={{ theme, toggleTheme, setTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+}
+
+export function useTheme() {
+  const context = useContext(ThemeContext);
+  if (context === undefined) {
+    throw new Error("useTheme must be used within a ThemeProvider");
+  }
+  return context;
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,8 +1,13 @@
 @import "tailwindcss";
 
 :root {
-  --background: #ffffff;
-  --foreground: #171717;
+  --background: #f6f8fa;
+  --foreground: #24292f;
+}
+
+.dark {
+  --background: #0d1117;
+  --foreground: #f6f8fa;
 }
 
 @theme inline {
@@ -12,18 +17,26 @@
   --font-mono: var(--font-geist-mono);
 }
 
-@media (prefers-color-scheme: dark) {
-  :root {
-    --background: #0a0a0a;
-    --foreground: #ededed;
-  }
-}
-
 body {
   background: var(--background);
   color: var(--foreground);
   font-family: var(--font-sans), Arial, Helvetica, sans-serif;
   min-height: 100vh;
+}
+
+/* Glassmorphism effects */
+.glass {
+  background: rgba(255, 255, 255, 0.15);
+  backdrop-filter: blur(10px);
+  -webkit-backdrop-filter: blur(10px);
+  border: 1px solid rgba(255, 255, 255, 0.18);
+}
+
+.dark .glass {
+  background: rgba(13, 17, 23, 0.75);
+  backdrop-filter: blur(10px);
+  -webkit-backdrop-filter: blur(10px);
+  border: 1px solid rgba(255, 255, 255, 0.08);
 }
 
 /* Custom scrollbar */
@@ -45,16 +58,14 @@ body {
   background: #555;
 }
 
-@media (prefers-color-scheme: dark) {
-  ::-webkit-scrollbar-track {
-    background: #1a1a1a;
-  }
+.dark ::-webkit-scrollbar-track {
+  background: #1a1a1a;
+}
 
-  ::-webkit-scrollbar-thumb {
-    background: #555;
-  }
+.dark ::-webkit-scrollbar-thumb {
+  background: #555;
+}
 
-  ::-webkit-scrollbar-thumb:hover {
-    background: #777;
-  }
+.dark ::-webkit-scrollbar-thumb:hover {
+  background: #777;
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -4,6 +4,8 @@ import "./globals.css";
 import AuthContext from "./context/AuthContext";
 import { GitHubProvider } from "./context/GitHubContext";
 import { NotificationsProvider } from "./context/NotificationsContext";
+import { NextUIProvider } from "@nextui-org/react";
+import { ThemeProvider } from "./context/ThemeContext";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -29,14 +31,18 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en">
+    <html lang="en" className="light">
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
         <AuthContext>
           <GitHubProvider>
             <NotificationsProvider>
-              {children}
+              <ThemeProvider>
+                <NextUIProvider>
+                  {children}
+                </NextUIProvider>
+              </ThemeProvider>
             </NotificationsProvider>
           </GitHubProvider>
         </AuthContext>

--- a/app/projects/[id]/page.tsx
+++ b/app/projects/[id]/page.tsx
@@ -1,0 +1,440 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { useParams, useRouter } from "next/navigation";
+import Link from "next/link";
+import { useGitHub } from "../../context/GitHubContext";
+import MainLayout from "../../components/layout/MainLayout";
+import ProjectColumn from "../../components/projects/ProjectColumn";
+import CreateColumnModal from "../../components/projects/CreateColumnModal";
+
+export default function ProjectDetailPage() {
+  const params = useParams();
+  const router = useRouter();
+  const projectId = parseInt(params.id as string, 10);
+  
+  const { githubService } = useGitHub();
+  const [project, setProject] = useState<any | null>(null);
+  const [columns, setColumns] = useState<any[]>([]);
+  const [cards, setCards] = useState<Record<number, any[]>>({});
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [showCreateColumnModal, setShowCreateColumnModal] = useState(false);
+  const [isEditingName, setIsEditingName] = useState(false);
+  const [isEditingDescription, setIsEditingDescription] = useState(false);
+  const [projectName, setProjectName] = useState("");
+  const [projectDescription, setProjectDescription] = useState("");
+
+  // Fetch project details
+  useEffect(() => {
+    async function fetchProjectDetails() {
+      if (!githubService) return;
+      
+      try {
+        setIsLoading(true);
+        setError(null);
+        
+        // Fetch project details
+        const projectData = await githubService.getProject(projectId);
+        setProject(projectData);
+        setProjectName(projectData.name);
+        setProjectDescription(projectData.body || "");
+        
+        // Fetch project columns
+        const columnsData = await githubService.getProjectColumns(projectId);
+        setColumns(columnsData);
+        
+        // Fetch cards for each column
+        const cardsData: Record<number, any[]> = {};
+        
+        for (const column of columnsData) {
+          const columnCards = await githubService.getColumnCards(column.id);
+          cardsData[column.id] = columnCards;
+        }
+        
+        setCards(cardsData);
+      } catch (err) {
+        console.error("Error fetching project details:", err);
+        setError("Failed to load project details. Please try again later.");
+      } finally {
+        setIsLoading(false);
+      }
+    }
+    
+    fetchProjectDetails();
+  }, [githubService, projectId]);
+
+  // Format date
+  const formatDate = (dateString: string) => {
+    const date = new Date(dateString);
+    return date.toLocaleDateString("en-US", {
+      year: "numeric",
+      month: "short",
+      day: "numeric",
+    });
+  };
+
+  // Handle project update
+  const handleUpdateProject = async (field: "name" | "body") => {
+    if (!githubService || !project) return;
+    
+    try {
+      setIsLoading(true);
+      
+      if (field === "name" && projectName.trim()) {
+        await githubService.updateProject(projectId, { name: projectName });
+        setProject({ ...project, name: projectName });
+        setIsEditingName(false);
+      } else if (field === "body") {
+        await githubService.updateProject(projectId, { body: projectDescription });
+        setProject({ ...project, body: projectDescription });
+        setIsEditingDescription(false);
+      }
+    } catch (error) {
+      console.error(`Error updating project ${field}:`, error);
+      alert(`Failed to update project ${field}. Please try again.`);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  // Handle project deletion
+  const handleDeleteProject = async () => {
+    if (!githubService || !project) return;
+    
+    if (window.confirm(`Are you sure you want to delete the project "${project.name}"?`)) {
+      try {
+        setIsLoading(true);
+        await githubService.deleteProject(projectId);
+        router.push("/projects");
+      } catch (error) {
+        console.error("Error deleting project:", error);
+        alert("Failed to delete project. Please try again.");
+        setIsLoading(false);
+      }
+    }
+  };
+
+  // Handle column creation
+  const handleColumnCreated = async (column: any) => {
+    setColumns([...columns, column]);
+    setCards({ ...cards, [column.id]: [] });
+  };
+
+  // Handle column deletion
+  const handleDeleteColumn = async (columnId: number) => {
+    setColumns(columns.filter(column => column.id !== columnId));
+    
+    const newCards = { ...cards };
+    delete newCards[columnId];
+    setCards(newCards);
+  };
+
+  // Handle column update
+  const handleUpdateColumn = async (columnId: number, name: string) => {
+    setColumns(columns.map(column => 
+      column.id === columnId ? { ...column, name } : column
+    ));
+  };
+
+  // Handle card creation
+  const handleAddCard = async (columnId: number) => {
+    if (!githubService) return;
+    
+    try {
+      // Refresh cards for the column
+      const columnCards = await githubService.getColumnCards(columnId);
+      setCards({ ...cards, [columnId]: columnCards });
+    } catch (error) {
+      console.error("Error refreshing cards:", error);
+    }
+  };
+
+  // Handle card deletion
+  const handleDeleteCard = async (cardId: number) => {
+    // Update cards state by removing the deleted card
+    const newCards = { ...cards };
+    
+    for (const columnId in newCards) {
+      newCards[columnId] = newCards[columnId].filter(card => card.id !== cardId);
+    }
+    
+    setCards(newCards);
+  };
+
+  // Handle card movement
+  const handleMoveCard = async (cardId: number, columnId: number, position: string) => {
+    if (!githubService) return;
+    
+    try {
+      // Refresh cards for all columns after movement
+      const updatedCards: Record<number, any[]> = {};
+      
+      for (const column of columns) {
+        const columnCards = await githubService.getColumnCards(column.id);
+        updatedCards[column.id] = columnCards;
+      }
+      
+      setCards(updatedCards);
+    } catch (error) {
+      console.error("Error refreshing cards after movement:", error);
+    }
+  };
+
+  if (isLoading && !project) {
+    return (
+      <MainLayout>
+        <div className="container mx-auto py-6">
+          <div className="flex justify-center items-center h-64">
+            <div className="animate-spin rounded-full h-12 w-12 border-t-2 border-b-2 border-blue-500"></div>
+          </div>
+        </div>
+      </MainLayout>
+    );
+  }
+
+  if (error) {
+    return (
+      <MainLayout>
+        <div className="container mx-auto py-6">
+          <div className="bg-red-100 dark:bg-red-900 text-red-800 dark:text-red-200 p-4 rounded-md">
+            {error}
+          </div>
+          <div className="mt-4">
+            <Link href="/projects" className="text-blue-600 dark:text-blue-400 hover:underline">
+              ← Back to Projects
+            </Link>
+          </div>
+        </div>
+      </MainLayout>
+    );
+  }
+
+  if (!project) {
+    return (
+      <MainLayout>
+        <div className="container mx-auto py-6">
+          <div className="bg-yellow-100 dark:bg-yellow-900 text-yellow-800 dark:text-yellow-200 p-4 rounded-md">
+            Project not found.
+          </div>
+          <div className="mt-4">
+            <Link href="/projects" className="text-blue-600 dark:text-blue-400 hover:underline">
+              ← Back to Projects
+            </Link>
+          </div>
+        </div>
+      </MainLayout>
+    );
+  }
+
+  return (
+    <MainLayout>
+      <div className="container mx-auto py-6">
+        <div className="mb-6">
+          <div className="flex items-center space-x-2 text-sm text-gray-600 dark:text-gray-400 mb-2">
+            <Link href="/projects" className="hover:text-blue-600 dark:hover:text-blue-400">
+              Projects
+            </Link>
+            <span>/</span>
+            <span className="text-gray-900 dark:text-gray-200">{project.name}</span>
+          </div>
+          
+          <div className="flex justify-between items-start">
+            <div className="flex-1">
+              {isEditingName ? (
+                <div className="mb-2">
+                  <input
+                    type="text"
+                    value={projectName}
+                    onChange={(e) => setProjectName(e.target.value)}
+                    className="w-full px-3 py-2 text-2xl font-bold border border-gray-300 dark:border-gray-600 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500 dark:bg-gray-800 dark:text-white"
+                    placeholder="Project name"
+                    autoFocus
+                  />
+                  <div className="flex mt-2 space-x-2">
+                    <button
+                      onClick={() => handleUpdateProject("name")}
+                      disabled={!projectName.trim()}
+                      className="px-3 py-1 bg-blue-600 text-white rounded-md hover:bg-blue-700 disabled:opacity-50"
+                    >
+                      Save
+                    </button>
+                    <button
+                      onClick={() => {
+                        setProjectName(project.name);
+                        setIsEditingName(false);
+                      }}
+                      className="px-3 py-1 bg-gray-500 text-white rounded-md hover:bg-gray-600"
+                    >
+                      Cancel
+                    </button>
+                  </div>
+                </div>
+              ) : (
+                <h1 className="text-2xl font-bold flex items-center">
+                  {project.name}
+                  <button
+                    onClick={() => setIsEditingName(true)}
+                    className="ml-2 text-gray-500 hover:text-blue-600 dark:text-gray-400 dark:hover:text-blue-400"
+                    title="Edit project name"
+                  >
+                    <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5" viewBox="0 0 20 20" fill="currentColor">
+                      <path d="M13.586 3.586a2 2 0 112.828 2.828l-.793.793-2.828-2.828.793-.793zM11.379 5.793L3 14.172V17h2.828l8.38-8.379-2.83-2.828z" />
+                    </svg>
+                  </button>
+                </h1>
+              )}
+              
+              <div className="mt-2 text-sm text-gray-600 dark:text-gray-400">
+                <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${
+                  project.state === "open"
+                    ? "bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200"
+                    : "bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-200"
+                }`}>
+                  {project.state}
+                </span>
+                <span className="mx-2">•</span>
+                <span>Created: {formatDate(project.created_at)}</span>
+                <span className="mx-2">•</span>
+                <span>Updated: {formatDate(project.updated_at)}</span>
+              </div>
+            </div>
+            
+            <div className="flex space-x-2">
+              <a
+                href={project.html_url}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="px-3 py-1 bg-gray-200 dark:bg-gray-700 text-gray-800 dark:text-gray-200 rounded-md hover:bg-gray-300 dark:hover:bg-gray-600 flex items-center"
+              >
+                <svg xmlns="http://www.w3.org/2000/svg" className="h-4 w-4 mr-1" viewBox="0 0 20 20" fill="currentColor">
+                  <path d="M11 3a1 1 0 100 2h2.586l-6.293 6.293a1 1 0 101.414 1.414L15 6.414V9a1 1 0 102 0V4a1 1 0 00-1-1h-5z" />
+                  <path d="M5 5a2 2 0 00-2 2v8a2 2 0 002 2h8a2 2 0 002-2v-3a1 1 0 10-2 0v3H5V7h3a1 1 0 000-2H5z" />
+                </svg>
+                View on GitHub
+              </a>
+              <button
+                onClick={handleDeleteProject}
+                className="px-3 py-1 bg-red-600 text-white rounded-md hover:bg-red-700 flex items-center"
+              >
+                <svg xmlns="http://www.w3.org/2000/svg" className="h-4 w-4 mr-1" viewBox="0 0 20 20" fill="currentColor">
+                  <path fillRule="evenodd" d="M9 2a1 1 0 00-.894.553L7.382 4H4a1 1 0 000 2v10a2 2 0 002 2h8a2 2 0 002-2V6a1 1 0 100-2h-3.382l-.724-1.447A1 1 0 0011 2H9zM7 8a1 1 0 012 0v6a1 1 0 11-2 0V8zm5-1a1 1 0 00-1 1v6a1 1 0 102 0V8a1 1 0 00-1-1z" clipRule="evenodd" />
+                </svg>
+                Delete Project
+              </button>
+            </div>
+          </div>
+          
+          <div className="mt-4">
+            {isEditingDescription ? (
+              <div>
+                <textarea
+                  value={projectDescription}
+                  onChange={(e) => setProjectDescription(e.target.value)}
+                  className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500 dark:bg-gray-800 dark:text-white"
+                  placeholder="Project description (optional)"
+                  rows={4}
+                />
+                <div className="flex mt-2 space-x-2">
+                  <button
+                    onClick={() => handleUpdateProject("body")}
+                    className="px-3 py-1 bg-blue-600 text-white rounded-md hover:bg-blue-700"
+                  >
+                    Save
+                  </button>
+                  <button
+                    onClick={() => {
+                      setProjectDescription(project.body || "");
+                      setIsEditingDescription(false);
+                    }}
+                    className="px-3 py-1 bg-gray-500 text-white rounded-md hover:bg-gray-600"
+                  >
+                    Cancel
+                  </button>
+                </div>
+              </div>
+            ) : (
+              <div className="bg-gray-50 dark:bg-gray-900 p-4 rounded-md relative group">
+                {project.body ? (
+                  <div className="prose dark:prose-invert max-w-none">
+                    {project.body}
+                  </div>
+                ) : (
+                  <p className="text-gray-500 dark:text-gray-400 italic">
+                    No description provided.
+                  </p>
+                )}
+                <button
+                  onClick={() => setIsEditingDescription(true)}
+                  className="absolute top-2 right-2 text-gray-400 hover:text-blue-600 dark:hover:text-blue-400 opacity-0 group-hover:opacity-100 transition-opacity"
+                  title="Edit description"
+                >
+                  <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5" viewBox="0 0 20 20" fill="currentColor">
+                    <path d="M13.586 3.586a2 2 0 112.828 2.828l-.793.793-2.828-2.828.793-.793zM11.379 5.793L3 14.172V17h2.828l8.38-8.379-2.83-2.828z" />
+                  </svg>
+                </button>
+              </div>
+            )}
+          </div>
+        </div>
+        
+        <div className="mt-8">
+          <div className="flex justify-between items-center mb-4">
+            <h2 className="text-xl font-semibold">Project Columns</h2>
+            <button
+              onClick={() => setShowCreateColumnModal(true)}
+              className="bg-blue-600 hover:bg-blue-700 text-white font-medium py-1 px-3 rounded-md transition-colors flex items-center text-sm"
+            >
+              <svg xmlns="http://www.w3.org/2000/svg" className="h-4 w-4 mr-1" viewBox="0 0 20 20" fill="currentColor">
+                <path fillRule="evenodd" d="M10 5a1 1 0 011 1v3h3a1 1 0 110 2h-3v3a1 1 0 11-2 0v-3H6a1 1 0 110-2h3V6a1 1 0 011-1z" clipRule="evenodd" />
+              </svg>
+              Add Column
+            </button>
+          </div>
+          
+          {columns.length > 0 ? (
+            <div className="flex space-x-4 overflow-x-auto pb-4">
+              {columns.map(column => (
+                <ProjectColumn
+                  key={column.id}
+                  column={column}
+                  cards={cards[column.id] || []}
+                  onDeleteColumn={handleDeleteColumn}
+                  onUpdateColumn={handleUpdateColumn}
+                  onAddCard={handleAddCard}
+                  onDeleteCard={handleDeleteCard}
+                  onMoveCard={handleMoveCard}
+                />
+              ))}
+            </div>
+          ) : (
+            <div className="bg-gray-50 dark:bg-gray-900 p-6 rounded-lg text-center">
+              <svg xmlns="http://www.w3.org/2000/svg" className="h-12 w-12 mx-auto text-gray-400 dark:text-gray-600 mb-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1} d="M9 17V7m0 10a2 2 0 01-2 2H5a2 2 0 01-2-2V7a2 2 0 012-2h2a2 2 0 012 2m0 10a2 2 0 002 2h2a2 2 0 002-2M9 7a2 2 0 012-2h2a2 2 0 012 2m0 10V7m0 10a2 2 0 002 2h2a2 2 0 002-2V7a2 2 0 00-2-2h-2a2 2 0 00-2 2" />
+              </svg>
+              <h3 className="text-lg font-medium text-gray-900 dark:text-gray-100 mb-2">No columns yet</h3>
+              <p className="text-gray-500 dark:text-gray-400 mb-4">
+                Add columns to organize your project tasks and issues.
+              </p>
+              <button
+                onClick={() => setShowCreateColumnModal(true)}
+                className="bg-blue-600 hover:bg-blue-700 text-white font-medium py-2 px-4 rounded-md transition-colors"
+              >
+                Add your first column
+              </button>
+            </div>
+          )}
+        </div>
+      </div>
+
+      {showCreateColumnModal && (
+        <CreateColumnModal
+          isOpen={showCreateColumnModal}
+          onClose={() => setShowCreateColumnModal(false)}
+          projectId={projectId}
+          onColumnCreated={handleColumnCreated}
+        />
+      )}
+    </MainLayout>
+  );
+}

--- a/app/projects/page.tsx
+++ b/app/projects/page.tsx
@@ -1,0 +1,174 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { useGitHub } from "../context/GitHubContext";
+import MainLayout from "../components/layout/MainLayout";
+import ProjectCard from "../components/projects/ProjectCard";
+import CreateProjectModal from "../components/projects/CreateProjectModal";
+
+export default function ProjectsPage() {
+  const { githubService } = useGitHub();
+  const [projects, setProjects] = useState<any[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [activeTab, setActiveTab] = useState<"user" | "repository" | "organization">("user");
+  const [showCreateModal, setShowCreateModal] = useState(false);
+
+  // Fetch projects based on active tab
+  useEffect(() => {
+    async function fetchProjects() {
+      if (githubService) {
+        try {
+          setIsLoading(true);
+          setError(null);
+          
+          let projectsData: any[] = [];
+          
+          switch (activeTab) {
+            case "user":
+              const user = await githubService.getCurrentUser();
+              projectsData = await githubService.getUserProjects(user.login);
+              break;
+            case "repository":
+              projectsData = await githubService.getAllRepositoryProjects();
+              break;
+            case "organization":
+              projectsData = await githubService.getAllOrganizationProjects();
+              break;
+          }
+          
+          setProjects(projectsData);
+        } catch (err) {
+          console.error("Error fetching projects:", err);
+          setError("Failed to fetch projects. Please try again later.");
+        } finally {
+          setIsLoading(false);
+        }
+      }
+    }
+    
+    fetchProjects();
+  }, [githubService, activeTab]);
+
+  // Handle project creation
+  const handleProjectCreated = (newProject: any) => {
+    if (
+      (activeTab === "user" && !newProject.owner_url) ||
+      (activeTab === "repository" && newProject.owner_url && !newProject.organization_url) ||
+      (activeTab === "organization" && newProject.organization_url)
+    ) {
+      setProjects([newProject, ...projects]);
+    }
+  };
+
+  // Handle project deletion
+  const handleProjectDeleted = (projectId: number) => {
+    setProjects(projects.filter(project => project.id !== projectId));
+  };
+
+  return (
+    <MainLayout>
+      <div className="container mx-auto py-6">
+        <div className="flex justify-between items-center mb-6">
+          <h1 className="text-2xl font-bold">GitHub Projects</h1>
+          <button
+            onClick={() => setShowCreateModal(true)}
+            className="bg-blue-600 hover:bg-blue-700 text-white font-medium py-2 px-4 rounded-lg transition-colors flex items-center"
+          >
+            <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5 mr-1" viewBox="0 0 20 20" fill="currentColor">
+              <path fillRule="evenodd" d="M10 5a1 1 0 011 1v3h3a1 1 0 110 2h-3v3a1 1 0 11-2 0v-3H6a1 1 0 110-2h3V6a1 1 0 011-1z" clipRule="evenodd" />
+            </svg>
+            Create Project
+          </button>
+        </div>
+
+        <div className="mb-6">
+          <div className="border-b border-gray-200 dark:border-gray-700">
+            <nav className="flex space-x-8">
+              <button
+                onClick={() => setActiveTab("user")}
+                className={`py-4 px-1 border-b-2 font-medium text-sm ${
+                  activeTab === "user"
+                    ? "border-blue-500 text-blue-600 dark:text-blue-400"
+                    : "border-transparent text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-300"
+                }`}
+              >
+                Your Projects
+              </button>
+              <button
+                onClick={() => setActiveTab("repository")}
+                className={`py-4 px-1 border-b-2 font-medium text-sm ${
+                  activeTab === "repository"
+                    ? "border-blue-500 text-blue-600 dark:text-blue-400"
+                    : "border-transparent text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-300"
+                }`}
+              >
+                Repository Projects
+              </button>
+              <button
+                onClick={() => setActiveTab("organization")}
+                className={`py-4 px-1 border-b-2 font-medium text-sm ${
+                  activeTab === "organization"
+                    ? "border-blue-500 text-blue-600 dark:text-blue-400"
+                    : "border-transparent text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-300"
+                }`}
+              >
+                Organization Projects
+              </button>
+            </nav>
+          </div>
+        </div>
+
+        {error && (
+          <div className="bg-red-100 dark:bg-red-900 text-red-800 dark:text-red-200 p-4 rounded-md mb-6">
+            {error}
+          </div>
+        )}
+
+        {isLoading ? (
+          <div className="flex justify-center items-center h-64">
+            <div className="animate-spin rounded-full h-12 w-12 border-t-2 border-b-2 border-blue-500"></div>
+          </div>
+        ) : projects.length > 0 ? (
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+            {projects.map(project => (
+              <ProjectCard
+                key={project.id}
+                project={project}
+                onDelete={handleProjectDeleted}
+              />
+            ))}
+          </div>
+        ) : (
+          <div className="text-center py-12">
+            <svg xmlns="http://www.w3.org/2000/svg" className="h-16 w-16 mx-auto text-gray-400 dark:text-gray-600 mb-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1} d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2" />
+            </svg>
+            <h3 className="text-lg font-medium text-gray-900 dark:text-gray-100 mb-2">No projects found</h3>
+            <p className="text-gray-500 dark:text-gray-400 mb-6">
+              {activeTab === "user"
+                ? "You haven't created any projects yet."
+                : activeTab === "repository"
+                ? "No repository projects found."
+                : "No organization projects found."}
+            </p>
+            <button
+              onClick={() => setShowCreateModal(true)}
+              className="bg-blue-600 hover:bg-blue-700 text-white font-medium py-2 px-4 rounded-lg transition-colors"
+            >
+              Create your first project
+            </button>
+          </div>
+        )}
+      </div>
+
+      {showCreateModal && (
+        <CreateProjectModal
+          isOpen={showCreateModal}
+          onClose={() => setShowCreateModal(false)}
+          onProjectCreated={handleProjectCreated}
+        />
+      )}
+    </MainLayout>
+  );
+}

--- a/app/services/github/githubService.ts
+++ b/app/services/github/githubService.ts
@@ -810,4 +810,221 @@ export class GitHubService {
     });
     return data;
   }
+
+  // GitHub Projects methods
+  async getOrganizationProjects(org: string, page = 1, perPage = 10) {
+    const { data } = await this.octokit.rest.projects.listForOrg({
+      org,
+      per_page: perPage,
+      page,
+      state: 'open',
+    });
+    return data;
+  }
+
+  async getUserProjects(username: string, page = 1, perPage = 10) {
+    const { data } = await this.octokit.rest.projects.listForUser({
+      username,
+      per_page: perPage,
+      page,
+      state: 'open',
+    });
+    return data;
+  }
+
+  async getRepositoryProjects(owner: string, repo: string, page = 1, perPage = 10) {
+    const { data } = await this.octokit.rest.projects.listForRepo({
+      owner,
+      repo,
+      per_page: perPage,
+      page,
+      state: 'open',
+    });
+    return data;
+  }
+
+  async getProject(project_id: number) {
+    const { data } = await this.octokit.rest.projects.get({
+      project_id,
+    });
+    return data;
+  }
+
+  async createProject(options: {
+    owner: string;
+    repo?: string;
+    name: string;
+    body?: string;
+    org?: string;
+  }) {
+    if (options.org) {
+      const { data } = await this.octokit.rest.projects.createForOrg({
+        org: options.org,
+        name: options.name,
+        body: options.body,
+      });
+      return data;
+    } else if (options.repo) {
+      const { data } = await this.octokit.rest.projects.createForRepo({
+        owner: options.owner,
+        repo: options.repo,
+        name: options.name,
+        body: options.body,
+      });
+      return data;
+    } else {
+      const { data } = await this.octokit.rest.projects.createForAuthenticatedUser({
+        name: options.name,
+        body: options.body,
+      });
+      return data;
+    }
+  }
+
+  async updateProject(project_id: number, options: {
+    name?: string;
+    body?: string;
+    state?: 'open' | 'closed';
+    organization_permission?: 'read' | 'write' | 'admin' | 'none';
+    private?: boolean;
+  }) {
+    const { data } = await this.octokit.rest.projects.update({
+      project_id,
+      ...options,
+    });
+    return data;
+  }
+
+  async deleteProject(project_id: number) {
+    const { data } = await this.octokit.rest.projects.delete({
+      project_id,
+    });
+    return data;
+  }
+
+  async getProjectColumns(project_id: number) {
+    const { data } = await this.octokit.rest.projects.listColumns({
+      project_id,
+    });
+    return data;
+  }
+
+  async getProjectColumn(column_id: number) {
+    const { data } = await this.octokit.rest.projects.getColumn({
+      column_id,
+    });
+    return data;
+  }
+
+  async createProjectColumn(project_id: number, name: string) {
+    const { data } = await this.octokit.rest.projects.createColumn({
+      project_id,
+      name,
+    });
+    return data;
+  }
+
+  async updateProjectColumn(column_id: number, name: string) {
+    const { data } = await this.octokit.rest.projects.updateColumn({
+      column_id,
+      name,
+    });
+    return data;
+  }
+
+  async deleteProjectColumn(column_id: number) {
+    const { data } = await this.octokit.rest.projects.deleteColumn({
+      column_id,
+    });
+    return data;
+  }
+
+  async moveProjectColumn(column_id: number, position: 'first' | 'last' | 'after:' | string) {
+    const { data } = await this.octokit.rest.projects.moveColumn({
+      column_id,
+      position,
+    });
+    return data;
+  }
+
+  async getColumnCards(column_id: number, page = 1, perPage = 100) {
+    const { data } = await this.octokit.rest.projects.listCards({
+      column_id,
+      per_page: perPage,
+      page,
+    });
+    return data;
+  }
+
+  async getCard(card_id: number) {
+    const { data } = await this.octokit.rest.projects.getCard({
+      card_id,
+    });
+    return data;
+  }
+
+  async createCard(column_id: number, options: {
+    note?: string;
+    content_id?: number;
+    content_type?: 'Issue' | 'PullRequest';
+  }) {
+    const { data } = await this.octokit.rest.projects.createCard({
+      column_id,
+      ...options,
+    });
+    return data;
+  }
+
+  async updateCard(card_id: number, note: string) {
+    const { data } = await this.octokit.rest.projects.updateCard({
+      card_id,
+      note,
+    });
+    return data;
+  }
+
+  async deleteCard(card_id: number) {
+    const { data } = await this.octokit.rest.projects.deleteCard({
+      card_id,
+    });
+    return data;
+  }
+
+  async moveCard(card_id: number, position: 'top' | 'bottom' | 'after:' | string, column_id?: number) {
+    const { data } = await this.octokit.rest.projects.moveCard({
+      card_id,
+      position,
+      column_id,
+    });
+    return data;
+  }
+
+  async getAllUserProjects() {
+    const user = await this.getCurrentUser();
+    return this.getUserProjects(user.login, 1, 100);
+  }
+
+  async getAllOrganizationProjects() {
+    const orgs = await this.getUserOrganizations();
+    let allProjects: any[] = [];
+
+    for (const org of orgs) {
+      const projects = await this.getOrganizationProjects(org.login, 1, 100);
+      allProjects = [...allProjects, ...projects];
+    }
+
+    return allProjects;
+  }
+
+  async getAllRepositoryProjects() {
+    const repos = await this.getUserRepositories();
+    let allProjects: any[] = [];
+
+    for (const repo of repos) {
+      const projects = await this.getRepositoryProjects(repo.owner.login, repo.name, 1, 100);
+      allProjects = [...allProjects, ...projects];
+    }
+
+    return allProjects;
+  }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,9 @@
       "name": "github-nexus",
       "version": "0.1.0",
       "dependencies": {
+        "@nextui-org/react": "^2.6.11",
         "chart.js": "^4.4.9",
+        "framer-motion": "^12.10.4",
         "next": "15.3.1",
         "next-auth": "^4.24.11",
         "octokit": "^4.1.3",
@@ -220,6 +222,57 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@formatjs/ecma402-abstract": {
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-2.3.4.tgz",
+      "integrity": "sha512-qrycXDeaORzIqNhBOx0btnhpD1c+/qFIHAN9znofuMJX6QBwtbrmlpWfD4oiUUD2vJUOIYFA/gYtg2KAMGG7sA==",
+      "license": "MIT",
+      "dependencies": {
+        "@formatjs/fast-memoize": "2.2.7",
+        "@formatjs/intl-localematcher": "0.6.1",
+        "decimal.js": "^10.4.3",
+        "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@formatjs/fast-memoize": {
+      "version": "2.2.7",
+      "resolved": "https://registry.npmjs.org/@formatjs/fast-memoize/-/fast-memoize-2.2.7.tgz",
+      "integrity": "sha512-Yabmi9nSvyOMrlSeGGWDiH7rf3a7sIwplbvo/dlz9WCIjzIQAfy1RMf4S0X3yG724n5Ghu2GmEl5NJIV6O9sZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@formatjs/icu-messageformat-parser": {
+      "version": "2.11.2",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-2.11.2.tgz",
+      "integrity": "sha512-AfiMi5NOSo2TQImsYAg8UYddsNJ/vUEv/HaNqiFjnI3ZFfWihUtD5QtuX6kHl8+H+d3qvnE/3HZrfzgdWpsLNA==",
+      "license": "MIT",
+      "dependencies": {
+        "@formatjs/ecma402-abstract": "2.3.4",
+        "@formatjs/icu-skeleton-parser": "1.8.14",
+        "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@formatjs/icu-skeleton-parser": {
+      "version": "1.8.14",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-skeleton-parser/-/icu-skeleton-parser-1.8.14.tgz",
+      "integrity": "sha512-i4q4V4qslThK4Ig8SxyD76cp3+QJ3sAqr7f6q9VVfeGtxG9OhiAk3y9XF6Q41OymsKzsGQ6OQQoJNY4/lI8TcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@formatjs/ecma402-abstract": "2.3.4",
+        "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@formatjs/intl-localematcher": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl-localematcher/-/intl-localematcher-0.6.1.tgz",
+      "integrity": "sha512-ePEgLgVCqi2BBFnTMWPfIghu6FkbZnnBVhO2sSxvLfrdFw7wCHAHiDoM2h4NRgjbaY7+B7HgOLZGkK187pZTZg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.8.0"
       }
     },
     "node_modules/@humanfs/core": {
@@ -665,6 +718,43 @@
         "url": "https://opencollective.com/libvips"
       }
     },
+    "node_modules/@internationalized/date": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@internationalized/date/-/date-3.6.0.tgz",
+      "integrity": "sha512-+z6ti+CcJnRlLHok/emGEsWQhe7kfSmEW+/6qCzvKY67YPh7YOBfvc7+/+NXq+zJlbArg30tYpqLjNgcAYv2YQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/helpers": "^0.5.0"
+      }
+    },
+    "node_modules/@internationalized/message": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/@internationalized/message/-/message-3.1.7.tgz",
+      "integrity": "sha512-gLQlhEW4iO7DEFPf/U7IrIdA3UyLGS0opeqouaFwlMObLUzwexRjbygONHDVbC9G9oFLXsLyGKYkJwqXw/QADg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/helpers": "^0.5.0",
+        "intl-messageformat": "^10.1.0"
+      }
+    },
+    "node_modules/@internationalized/number": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/@internationalized/number/-/number-3.6.1.tgz",
+      "integrity": "sha512-UVsb4bCwbL944E0SX50CHFtWEeZ2uB5VozZ5yDXJdq6iPZsZO5p+bjVMZh2GxHf4Bs/7xtDCcPwEa2NU9DaG/g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/helpers": "^0.5.0"
+      }
+    },
+    "node_modules/@internationalized/string": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@internationalized/string/-/string-3.2.6.tgz",
+      "integrity": "sha512-LR2lnM4urJta5/wYJVV7m8qk5DrMZmLRTuFhbQO5b9/sKLHgty6unQy1Li4+Su2DWydmB4aZdS5uxBRXIq2aAw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/helpers": "^0.5.0"
+      }
+    },
     "node_modules/@kurkle/color": {
       "version": "0.3.4",
       "resolved": "https://registry.npmjs.org/@kurkle/color/-/color-0.3.4.tgz",
@@ -848,6 +938,1546 @@
       ],
       "engines": {
         "node": ">= 10"
+      }
+    },
+    "node_modules/@nextui-org/accordion": {
+      "version": "2.2.7",
+      "resolved": "https://registry.npmjs.org/@nextui-org/accordion/-/accordion-2.2.7.tgz",
+      "integrity": "sha512-jdobOwUxSi617m+LpxHFzg64UhDuOfDJI2CMk3MP+b2WBJ7SNW4hmN2NW5Scx5JiY+kyBGmlxJ4Y++jZpZgQjQ==",
+      "deprecated": "This package has been deprecated. Please use @heroui/accordion instead.",
+      "license": "MIT",
+      "dependencies": {
+        "@nextui-org/aria-utils": "2.2.7",
+        "@nextui-org/divider": "2.2.5",
+        "@nextui-org/dom-animation": "2.1.1",
+        "@nextui-org/framer-utils": "2.1.6",
+        "@nextui-org/react-utils": "2.1.3",
+        "@nextui-org/shared-icons": "2.1.1",
+        "@nextui-org/shared-utils": "2.1.2",
+        "@nextui-org/use-aria-accordion": "2.2.2",
+        "@react-aria/button": "3.11.0",
+        "@react-aria/focus": "3.19.0",
+        "@react-aria/interactions": "3.22.5",
+        "@react-aria/utils": "3.26.0",
+        "@react-stately/tree": "3.8.6",
+        "@react-types/accordion": "3.0.0-alpha.25",
+        "@react-types/shared": "3.26.0"
+      },
+      "peerDependencies": {
+        "@nextui-org/system": ">=2.4.0",
+        "@nextui-org/theme": ">=2.4.0",
+        "framer-motion": ">=11.5.6 || >=12.0.0-alpha.1",
+        "react": ">=18 || >=19.0.0-rc.0",
+        "react-dom": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@nextui-org/alert": {
+      "version": "2.2.9",
+      "resolved": "https://registry.npmjs.org/@nextui-org/alert/-/alert-2.2.9.tgz",
+      "integrity": "sha512-SjMZewEqknx/jqmMcyQdbeo6RFg40+A3b1lGjnj/fdkiJozQoTesiOslzDsacqiSgvso2F+8u1emC2tFBAU3hw==",
+      "deprecated": "This package has been deprecated. Please use @heroui/alert instead.",
+      "license": "MIT",
+      "dependencies": {
+        "@nextui-org/button": "2.2.9",
+        "@nextui-org/react-utils": "2.1.3",
+        "@nextui-org/shared-icons": "2.1.1",
+        "@nextui-org/shared-utils": "2.1.2",
+        "@react-aria/utils": "3.26.0",
+        "@react-stately/utils": "3.10.5"
+      },
+      "peerDependencies": {
+        "@nextui-org/system": ">=2.4.0",
+        "@nextui-org/theme": ">=2.4.0",
+        "react": ">=18 || >=19.0.0-rc.0",
+        "react-dom": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@nextui-org/aria-utils": {
+      "version": "2.2.7",
+      "resolved": "https://registry.npmjs.org/@nextui-org/aria-utils/-/aria-utils-2.2.7.tgz",
+      "integrity": "sha512-QgMZ8fii6BCI/+ZIkgXgkm/gMNQ92pQJn83q90fBT6DF+6j4hsCpJwLNCF5mIJkX/cQ/4bHDsDaj7w1OzkhQNg==",
+      "license": "MIT",
+      "dependencies": {
+        "@nextui-org/react-rsc-utils": "2.1.1",
+        "@nextui-org/shared-utils": "2.1.2",
+        "@nextui-org/system": "2.4.6",
+        "@react-aria/utils": "3.26.0",
+        "@react-stately/collections": "3.12.0",
+        "@react-stately/overlays": "3.6.12",
+        "@react-types/overlays": "3.8.11",
+        "@react-types/shared": "3.26.0"
+      },
+      "peerDependencies": {
+        "react": ">=18 || >=19.0.0-rc.0",
+        "react-dom": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@nextui-org/autocomplete": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@nextui-org/autocomplete/-/autocomplete-2.3.9.tgz",
+      "integrity": "sha512-1AizOvL8lERoWjm8WiA0NPJWB3h0gqYlbV/qGZeacac5356hb8cNzWUlxGzr9bNkhn9slIoEUyGMgtYeKq7ptg==",
+      "deprecated": "This package has been deprecated. Please use @heroui/autocomplete instead.",
+      "license": "MIT",
+      "dependencies": {
+        "@nextui-org/aria-utils": "2.2.7",
+        "@nextui-org/button": "2.2.9",
+        "@nextui-org/form": "2.1.8",
+        "@nextui-org/input": "2.4.8",
+        "@nextui-org/listbox": "2.3.9",
+        "@nextui-org/popover": "2.3.9",
+        "@nextui-org/react-utils": "2.1.3",
+        "@nextui-org/scroll-shadow": "2.3.5",
+        "@nextui-org/shared-icons": "2.1.1",
+        "@nextui-org/shared-utils": "2.1.2",
+        "@nextui-org/spinner": "2.2.6",
+        "@nextui-org/use-aria-button": "2.2.4",
+        "@nextui-org/use-safe-layout-effect": "2.1.1",
+        "@react-aria/combobox": "3.11.0",
+        "@react-aria/focus": "3.19.0",
+        "@react-aria/i18n": "3.12.4",
+        "@react-aria/interactions": "3.22.5",
+        "@react-aria/utils": "3.26.0",
+        "@react-aria/visually-hidden": "3.8.18",
+        "@react-stately/combobox": "3.10.1",
+        "@react-types/combobox": "3.13.1",
+        "@react-types/shared": "3.26.0"
+      },
+      "peerDependencies": {
+        "@nextui-org/system": ">=2.4.0",
+        "@nextui-org/theme": ">=2.4.0",
+        "framer-motion": ">=11.5.6 || >=12.0.0-alpha.1",
+        "react": ">=18 || >=19.0.0-rc.0",
+        "react-dom": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@nextui-org/avatar": {
+      "version": "2.2.6",
+      "resolved": "https://registry.npmjs.org/@nextui-org/avatar/-/avatar-2.2.6.tgz",
+      "integrity": "sha512-QRNCAMXnSZrFJYKo78lzRPiAPRq5pn1LIHUVvX/mCRiTvbu1FXrMakAvOWz/n1X1mLndnrfQMRNgmtC8YlHIdg==",
+      "deprecated": "This package has been deprecated. Please use @heroui/avatar instead.",
+      "license": "MIT",
+      "dependencies": {
+        "@nextui-org/react-utils": "2.1.3",
+        "@nextui-org/shared-utils": "2.1.2",
+        "@nextui-org/use-image": "2.1.2",
+        "@react-aria/focus": "3.19.0",
+        "@react-aria/interactions": "3.22.5",
+        "@react-aria/utils": "3.26.0"
+      },
+      "peerDependencies": {
+        "@nextui-org/system": ">=2.4.0",
+        "@nextui-org/theme": ">=2.4.0",
+        "react": ">=18 || >=19.0.0-rc.0",
+        "react-dom": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@nextui-org/badge": {
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/@nextui-org/badge/-/badge-2.2.5.tgz",
+      "integrity": "sha512-8pLbuY+RVCzI/00CzNudc86BiuXByPFz2yHh00djKvZAXbT0lfjvswClJxSC2FjUXlod+NtE+eHmlhSMo3gmpw==",
+      "deprecated": "This package has been deprecated. Please use @heroui/badge instead.",
+      "license": "MIT",
+      "dependencies": {
+        "@nextui-org/react-utils": "2.1.3",
+        "@nextui-org/shared-utils": "2.1.2"
+      },
+      "peerDependencies": {
+        "@nextui-org/system": ">=2.4.0",
+        "@nextui-org/theme": ">=2.4.0",
+        "react": ">=18 || >=19.0.0-rc.0",
+        "react-dom": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@nextui-org/breadcrumbs": {
+      "version": "2.2.6",
+      "resolved": "https://registry.npmjs.org/@nextui-org/breadcrumbs/-/breadcrumbs-2.2.6.tgz",
+      "integrity": "sha512-TlAUSiIClmm02tJqOvtwySpKDOENduXCXkKzCbmSaqEFhziHnhyE0eM8IVEprBoK6z1VP+sUrX6C2gZ871KUSw==",
+      "deprecated": "This package has been deprecated. Please use @heroui/breadcrumbs instead.",
+      "license": "MIT",
+      "dependencies": {
+        "@nextui-org/react-utils": "2.1.3",
+        "@nextui-org/shared-icons": "2.1.1",
+        "@nextui-org/shared-utils": "2.1.2",
+        "@react-aria/breadcrumbs": "3.5.19",
+        "@react-aria/focus": "3.19.0",
+        "@react-aria/utils": "3.26.0",
+        "@react-types/breadcrumbs": "3.7.9",
+        "@react-types/shared": "3.26.0"
+      },
+      "peerDependencies": {
+        "@nextui-org/system": ">=2.4.0",
+        "@nextui-org/theme": ">=2.4.0",
+        "react": ">=18 || >=19.0.0-rc.0",
+        "react-dom": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@nextui-org/button": {
+      "version": "2.2.9",
+      "resolved": "https://registry.npmjs.org/@nextui-org/button/-/button-2.2.9.tgz",
+      "integrity": "sha512-RrfjAZHoc6nmaqoLj40M0Qj3tuDdv2BMGCgggyWklOi6lKwtOaADPvxEorDwY3GnN54Xej+9SWtUwE8Oc3SnOg==",
+      "deprecated": "This package has been deprecated. Please use @heroui/button instead.",
+      "license": "MIT",
+      "dependencies": {
+        "@nextui-org/react-utils": "2.1.3",
+        "@nextui-org/ripple": "2.2.7",
+        "@nextui-org/shared-utils": "2.1.2",
+        "@nextui-org/spinner": "2.2.6",
+        "@nextui-org/use-aria-button": "2.2.4",
+        "@react-aria/button": "3.11.0",
+        "@react-aria/focus": "3.19.0",
+        "@react-aria/interactions": "3.22.5",
+        "@react-aria/utils": "3.26.0",
+        "@react-types/button": "3.10.1",
+        "@react-types/shared": "3.26.0"
+      },
+      "peerDependencies": {
+        "@nextui-org/system": ">=2.4.0",
+        "@nextui-org/theme": ">=2.4.0",
+        "framer-motion": ">=11.5.6 || >=12.0.0-alpha.1",
+        "react": ">=18 || >=19.0.0-rc.0",
+        "react-dom": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@nextui-org/calendar": {
+      "version": "2.2.9",
+      "resolved": "https://registry.npmjs.org/@nextui-org/calendar/-/calendar-2.2.9.tgz",
+      "integrity": "sha512-tx1401HLnwadoDHNkmEIZNeAw9uYW6KsgIRRQnXTNVstBXdMmPWjoMBj8fkQqF55+U58k6a+w3N4tTpgRGOpaQ==",
+      "deprecated": "This package has been deprecated. Please use @heroui/calendar instead.",
+      "license": "MIT",
+      "dependencies": {
+        "@internationalized/date": "3.6.0",
+        "@nextui-org/button": "2.2.9",
+        "@nextui-org/dom-animation": "2.1.1",
+        "@nextui-org/framer-utils": "2.1.6",
+        "@nextui-org/react-utils": "2.1.3",
+        "@nextui-org/shared-icons": "2.1.1",
+        "@nextui-org/shared-utils": "2.1.2",
+        "@nextui-org/use-aria-button": "2.2.4",
+        "@react-aria/calendar": "3.6.0",
+        "@react-aria/focus": "3.19.0",
+        "@react-aria/i18n": "3.12.4",
+        "@react-aria/interactions": "3.22.5",
+        "@react-aria/utils": "3.26.0",
+        "@react-aria/visually-hidden": "3.8.18",
+        "@react-stately/calendar": "3.6.0",
+        "@react-stately/utils": "3.10.5",
+        "@react-types/button": "3.10.1",
+        "@react-types/calendar": "3.5.0",
+        "@react-types/shared": "3.26.0",
+        "@types/lodash.debounce": "^4.0.7",
+        "scroll-into-view-if-needed": "3.0.10"
+      },
+      "peerDependencies": {
+        "@nextui-org/system": ">=2.4.0",
+        "@nextui-org/theme": ">=2.4.0",
+        "framer-motion": ">=11.5.6 || >=12.0.0-alpha.1",
+        "react": ">=18 || >=19.0.0-rc.0",
+        "react-dom": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@nextui-org/card": {
+      "version": "2.2.9",
+      "resolved": "https://registry.npmjs.org/@nextui-org/card/-/card-2.2.9.tgz",
+      "integrity": "sha512-Ltvb5Uy4wwkBJj3QvVQmoB6PwLYUNSoWAFo2xxu7LUHKWcETYI0YbUIuwL2nFU2xfJYeBTGjXGQO1ffBsowrtQ==",
+      "deprecated": "This package has been deprecated. Please use @heroui/card instead.",
+      "license": "MIT",
+      "dependencies": {
+        "@nextui-org/react-utils": "2.1.3",
+        "@nextui-org/ripple": "2.2.7",
+        "@nextui-org/shared-utils": "2.1.2",
+        "@nextui-org/use-aria-button": "2.2.4",
+        "@react-aria/button": "3.11.0",
+        "@react-aria/focus": "3.19.0",
+        "@react-aria/interactions": "3.22.5",
+        "@react-aria/utils": "3.26.0",
+        "@react-types/shared": "3.26.0"
+      },
+      "peerDependencies": {
+        "@nextui-org/system": ">=2.4.0",
+        "@nextui-org/theme": ">=2.4.0",
+        "framer-motion": ">=11.5.6 || >=12.0.0-alpha.1",
+        "react": ">=18 || >=19.0.0-rc.0",
+        "react-dom": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@nextui-org/checkbox": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/@nextui-org/checkbox/-/checkbox-2.3.8.tgz",
+      "integrity": "sha512-T5+AhzQfbg53qZnPn5rgMcJ7T5rnvSGYTx17wHWtdF9Q4QflZOmLGoxqoTWbTVpM4XzUUPyi7KVSKZScWdBDAA==",
+      "deprecated": "This package has been deprecated. Please use @heroui/checkbox instead.",
+      "license": "MIT",
+      "dependencies": {
+        "@nextui-org/form": "2.1.8",
+        "@nextui-org/react-utils": "2.1.3",
+        "@nextui-org/shared-utils": "2.1.2",
+        "@nextui-org/use-callback-ref": "2.1.1",
+        "@nextui-org/use-safe-layout-effect": "2.1.1",
+        "@react-aria/checkbox": "3.15.0",
+        "@react-aria/focus": "3.19.0",
+        "@react-aria/interactions": "3.22.5",
+        "@react-aria/utils": "3.26.0",
+        "@react-aria/visually-hidden": "3.8.18",
+        "@react-stately/checkbox": "3.6.10",
+        "@react-stately/toggle": "3.8.0",
+        "@react-types/checkbox": "3.9.0",
+        "@react-types/shared": "3.26.0"
+      },
+      "peerDependencies": {
+        "@nextui-org/system": ">=2.4.0",
+        "@nextui-org/theme": ">=2.4.3",
+        "react": ">=18 || >=19.0.0-rc.0",
+        "react-dom": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@nextui-org/chip": {
+      "version": "2.2.6",
+      "resolved": "https://registry.npmjs.org/@nextui-org/chip/-/chip-2.2.6.tgz",
+      "integrity": "sha512-HrSYagbrD4u4nblsNMIu7WGnDj9A8YnYCt30tasJmNSyydUVHFkxKOc3S8k+VU3BHPxeENxeBT7w0OlYoKbFIQ==",
+      "deprecated": "This package has been deprecated. Please use @heroui/chip instead.",
+      "license": "MIT",
+      "dependencies": {
+        "@nextui-org/react-utils": "2.1.3",
+        "@nextui-org/shared-icons": "2.1.1",
+        "@nextui-org/shared-utils": "2.1.2",
+        "@react-aria/focus": "3.19.0",
+        "@react-aria/interactions": "3.22.5",
+        "@react-aria/utils": "3.26.0",
+        "@react-types/checkbox": "3.9.0"
+      },
+      "peerDependencies": {
+        "@nextui-org/system": ">=2.4.0",
+        "@nextui-org/theme": ">=2.4.0",
+        "react": ">=18 || >=19.0.0-rc.0",
+        "react-dom": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@nextui-org/code": {
+      "version": "2.2.6",
+      "resolved": "https://registry.npmjs.org/@nextui-org/code/-/code-2.2.6.tgz",
+      "integrity": "sha512-8qvAywIKAVh1thy/YHNwqH2xjTcwPiOWwNdKqvJMSk0CNtLHYJmDK8i2vmKZTM3zfB08Q/G94H0Wf+YsyrZdDg==",
+      "deprecated": "This package has been deprecated. Please use @heroui/code instead.",
+      "license": "MIT",
+      "dependencies": {
+        "@nextui-org/react-utils": "2.1.3",
+        "@nextui-org/shared-utils": "2.1.2",
+        "@nextui-org/system-rsc": "2.3.5"
+      },
+      "peerDependencies": {
+        "@nextui-org/theme": ">=2.4.0",
+        "react": ">=18 || >=19.0.0-rc.0",
+        "react-dom": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@nextui-org/date-input": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/@nextui-org/date-input/-/date-input-2.3.8.tgz",
+      "integrity": "sha512-phj0Y8F/GpsKjKSiratFwh7HDzmMsIf6G2L2ljgWqA79PvP+RYf/ogEfaMIq1knF8OlssMo5nsFFJNsNB+xKGg==",
+      "deprecated": "This package has been deprecated. Please use @heroui/date-input instead.",
+      "license": "MIT",
+      "dependencies": {
+        "@internationalized/date": "3.6.0",
+        "@nextui-org/form": "2.1.8",
+        "@nextui-org/react-utils": "2.1.3",
+        "@nextui-org/shared-utils": "2.1.2",
+        "@react-aria/datepicker": "3.12.0",
+        "@react-aria/i18n": "3.12.4",
+        "@react-aria/utils": "3.26.0",
+        "@react-stately/datepicker": "3.11.0",
+        "@react-types/datepicker": "3.9.0",
+        "@react-types/shared": "3.26.0"
+      },
+      "peerDependencies": {
+        "@nextui-org/system": ">=2.4.0",
+        "@nextui-org/theme": ">=2.4.0",
+        "react": ">=18 || >=19.0.0-rc.0",
+        "react-dom": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@nextui-org/date-picker": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@nextui-org/date-picker/-/date-picker-2.3.9.tgz",
+      "integrity": "sha512-RzdVTl/tulTyE5fwGkQfn0is5hsTkPPRJFJZXMqYeci85uhpD+bCreWnTXrGFIXcqUo0ZBJWx3EdtBJZnGp4xQ==",
+      "deprecated": "This package has been deprecated. Please use @heroui/date-picker instead.",
+      "license": "MIT",
+      "dependencies": {
+        "@internationalized/date": "3.6.0",
+        "@nextui-org/aria-utils": "2.2.7",
+        "@nextui-org/button": "2.2.9",
+        "@nextui-org/calendar": "2.2.9",
+        "@nextui-org/date-input": "2.3.8",
+        "@nextui-org/form": "2.1.8",
+        "@nextui-org/popover": "2.3.9",
+        "@nextui-org/react-utils": "2.1.3",
+        "@nextui-org/shared-icons": "2.1.1",
+        "@nextui-org/shared-utils": "2.1.2",
+        "@react-aria/datepicker": "3.12.0",
+        "@react-aria/i18n": "3.12.4",
+        "@react-aria/utils": "3.26.0",
+        "@react-stately/datepicker": "3.11.0",
+        "@react-stately/overlays": "3.6.12",
+        "@react-stately/utils": "3.10.5",
+        "@react-types/datepicker": "3.9.0",
+        "@react-types/shared": "3.26.0"
+      },
+      "peerDependencies": {
+        "@nextui-org/system": ">=2.4.0",
+        "@nextui-org/theme": ">=2.4.0",
+        "framer-motion": ">=11.5.6 || >=12.0.0-alpha.1",
+        "react": ">=18 || >=19.0.0-rc.0",
+        "react-dom": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@nextui-org/divider": {
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/@nextui-org/divider/-/divider-2.2.5.tgz",
+      "integrity": "sha512-OB8b3CU4nQ5ARIGL48izhzrAHR0mnwws+Kd5LqRCZ/1R9uRMqsq7L0gpG9FkuV2jf2FuA7xa/GLOLKbIl4CEww==",
+      "deprecated": "This package has been deprecated. Please use @heroui/divider instead.",
+      "license": "MIT",
+      "dependencies": {
+        "@nextui-org/react-rsc-utils": "2.1.1",
+        "@nextui-org/shared-utils": "2.1.2",
+        "@nextui-org/system-rsc": "2.3.5",
+        "@react-types/shared": "3.26.0"
+      },
+      "peerDependencies": {
+        "@nextui-org/theme": ">=2.4.0",
+        "react": ">=18 || >=19.0.0-rc.0",
+        "react-dom": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@nextui-org/dom-animation": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@nextui-org/dom-animation/-/dom-animation-2.1.1.tgz",
+      "integrity": "sha512-xLrVNf1EV9zyyZjk6j3RptOvnga1WUCbMpDgJLQHp+oYwxTfBy0SkXHuN5pRdcR0XpR/IqRBDIobMdZI0iyQyg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "framer-motion": ">=11.5.6 || >=12.0.0-alpha.1"
+      }
+    },
+    "node_modules/@nextui-org/drawer": {
+      "version": "2.2.7",
+      "resolved": "https://registry.npmjs.org/@nextui-org/drawer/-/drawer-2.2.7.tgz",
+      "integrity": "sha512-a1Sr3sSjOZD0SiXDYSySKkOelTyCYExPvUsIckzjF5A3TNlBw4KFKnJzaXvabC3SNRy6/Ocq7oqz6VRv37wxQg==",
+      "deprecated": "This package has been deprecated. Please use @heroui/drawer instead.",
+      "license": "MIT",
+      "dependencies": {
+        "@nextui-org/framer-utils": "2.1.6",
+        "@nextui-org/modal": "2.2.7",
+        "@nextui-org/react-utils": "2.1.3",
+        "@nextui-org/shared-utils": "2.1.2"
+      },
+      "peerDependencies": {
+        "@nextui-org/system": ">=2.4.0",
+        "@nextui-org/theme": ">=2.4.0",
+        "react": ">=18 || >=19.0.0-rc.0",
+        "react-dom": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@nextui-org/dropdown": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@nextui-org/dropdown/-/dropdown-2.3.9.tgz",
+      "integrity": "sha512-ElZxiP+nG0CKC+tm6LMZX42cRWXQ0LLjWBZXymupPsEH3XcQpCF9GWb9efJ2hh+qGROg7i0bnFH7P0GTyCyNBA==",
+      "deprecated": "This package has been deprecated. Please use @heroui/dropdown instead.",
+      "license": "MIT",
+      "dependencies": {
+        "@nextui-org/aria-utils": "2.2.7",
+        "@nextui-org/menu": "2.2.9",
+        "@nextui-org/popover": "2.3.9",
+        "@nextui-org/react-utils": "2.1.3",
+        "@nextui-org/shared-utils": "2.1.2",
+        "@react-aria/focus": "3.19.0",
+        "@react-aria/menu": "3.16.0",
+        "@react-aria/utils": "3.26.0",
+        "@react-stately/menu": "3.9.0",
+        "@react-types/menu": "3.9.13"
+      },
+      "peerDependencies": {
+        "@nextui-org/system": ">=2.4.0",
+        "@nextui-org/theme": ">=2.4.0",
+        "framer-motion": ">=11.5.6 || >=12.0.0-alpha.1",
+        "react": ">=18 || >=19.0.0-rc.0",
+        "react-dom": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@nextui-org/form": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/@nextui-org/form/-/form-2.1.8.tgz",
+      "integrity": "sha512-Xn/dUO5zDG7zukbql1MDYh4Xwe1vnIVMRTHgckbkBtXXVNqgoTU09TTfy8WOJ0pMDX4GrZSBAZ86o37O+IHbaA==",
+      "deprecated": "This package has been deprecated. Please use @heroui/form instead.",
+      "license": "MIT",
+      "dependencies": {
+        "@nextui-org/react-utils": "2.1.3",
+        "@nextui-org/shared-utils": "2.1.2",
+        "@nextui-org/system": "2.4.6",
+        "@nextui-org/theme": "2.4.5",
+        "@react-aria/utils": "3.26.0",
+        "@react-stately/form": "3.1.0",
+        "@react-types/form": "3.7.8",
+        "@react-types/shared": "3.26.0"
+      },
+      "peerDependencies": {
+        "@nextui-org/system": ">=2.4.0",
+        "@nextui-org/theme": ">=2.4.0",
+        "react": ">=18",
+        "react-dom": ">=18"
+      }
+    },
+    "node_modules/@nextui-org/framer-utils": {
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/@nextui-org/framer-utils/-/framer-utils-2.1.6.tgz",
+      "integrity": "sha512-b+BxKFox8j9rNAaL+CRe2ZMb1/SKjz9Kl2eLjDSsq3q82K/Hg7lEjlpgE8cu41wIGjH1unQxtP+btiJgl067Ow==",
+      "license": "MIT",
+      "dependencies": {
+        "@nextui-org/shared-utils": "2.1.2",
+        "@nextui-org/system": "2.4.6",
+        "@nextui-org/use-measure": "2.1.1"
+      },
+      "peerDependencies": {
+        "framer-motion": ">=11.5.6 || >=12.0.0-alpha.1",
+        "react": ">=18 || >=19.0.0-rc.0",
+        "react-dom": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@nextui-org/image": {
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/@nextui-org/image/-/image-2.2.5.tgz",
+      "integrity": "sha512-A6DnEqG+/cMrfvqFKKJIdGD7gD88tVkqGxRkfysVMJJR96sDIYCJlP1jsAEtYKh4PfhmtJWclUvY/x9fMw0H1w==",
+      "deprecated": "This package has been deprecated. Please use @heroui/image instead.",
+      "license": "MIT",
+      "dependencies": {
+        "@nextui-org/react-utils": "2.1.3",
+        "@nextui-org/shared-utils": "2.1.2",
+        "@nextui-org/use-image": "2.1.2"
+      },
+      "peerDependencies": {
+        "@nextui-org/system": ">=2.4.0",
+        "@nextui-org/theme": ">=2.4.0",
+        "react": ">=18 || >=19.0.0-rc.0",
+        "react-dom": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@nextui-org/input": {
+      "version": "2.4.8",
+      "resolved": "https://registry.npmjs.org/@nextui-org/input/-/input-2.4.8.tgz",
+      "integrity": "sha512-wfkjyl7vRqT3HDXeybhfZ+IAz+Z02U5EiuWPpc9NbdwhJ/LpDRDa6fYcTDr/6j6MiyrEZsM24CtZZKAKBVBquQ==",
+      "deprecated": "This package has been deprecated. Please use @heroui/input instead.",
+      "license": "MIT",
+      "dependencies": {
+        "@nextui-org/form": "2.1.8",
+        "@nextui-org/react-utils": "2.1.3",
+        "@nextui-org/shared-icons": "2.1.1",
+        "@nextui-org/shared-utils": "2.1.2",
+        "@nextui-org/use-safe-layout-effect": "2.1.1",
+        "@react-aria/focus": "3.19.0",
+        "@react-aria/interactions": "3.22.5",
+        "@react-aria/textfield": "3.15.0",
+        "@react-aria/utils": "3.26.0",
+        "@react-stately/utils": "3.10.5",
+        "@react-types/shared": "3.26.0",
+        "@react-types/textfield": "3.10.0",
+        "react-textarea-autosize": "^8.5.3"
+      },
+      "peerDependencies": {
+        "@nextui-org/system": ">=2.4.0",
+        "@nextui-org/theme": ">=2.4.0",
+        "react": ">=18 || >=19.0.0-rc.0",
+        "react-dom": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@nextui-org/input-otp": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/@nextui-org/input-otp/-/input-otp-2.1.8.tgz",
+      "integrity": "sha512-J5Pz0aSfWD+2cSgLTKQamCNF/qHILIj8L0lY3t1R/sgK1ApN3kDNcUGnVm6EDh+dOXITKpCfnsCQw834nxZhsg==",
+      "deprecated": "This package has been deprecated. Please use @heroui/input-otp instead.",
+      "license": "MIT",
+      "dependencies": {
+        "@nextui-org/form": "2.1.8",
+        "@nextui-org/react-utils": "2.1.3",
+        "@nextui-org/shared-utils": "2.1.2",
+        "@react-aria/focus": "3.19.0",
+        "@react-aria/form": "3.0.11",
+        "@react-aria/utils": "3.26.0",
+        "@react-stately/form": "3.1.0",
+        "@react-stately/utils": "3.10.5",
+        "@react-types/textfield": "3.10.0",
+        "input-otp": "1.4.1"
+      },
+      "peerDependencies": {
+        "@nextui-org/system": ">=2.4.0",
+        "@nextui-org/theme": ">=2.4.0",
+        "react": ">=18",
+        "react-dom": ">=18"
+      }
+    },
+    "node_modules/@nextui-org/kbd": {
+      "version": "2.2.6",
+      "resolved": "https://registry.npmjs.org/@nextui-org/kbd/-/kbd-2.2.6.tgz",
+      "integrity": "sha512-IwzvvwYLMbhyqX5PjEZyDBO4iNEHY6Nek4ZrVR+Z2dOSj/oZXHWiabNDrvOcGKgUBE6xc95Fi1jVubE9b5ueuA==",
+      "deprecated": "This package has been deprecated. Please use @heroui/kbd instead.",
+      "license": "MIT",
+      "dependencies": {
+        "@nextui-org/react-utils": "2.1.3",
+        "@nextui-org/shared-utils": "2.1.2",
+        "@nextui-org/system-rsc": "2.3.5",
+        "@react-aria/utils": "3.26.0"
+      },
+      "peerDependencies": {
+        "@nextui-org/theme": ">=2.4.0",
+        "react": ">=18 || >=19.0.0-rc.0",
+        "react-dom": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@nextui-org/link": {
+      "version": "2.2.7",
+      "resolved": "https://registry.npmjs.org/@nextui-org/link/-/link-2.2.7.tgz",
+      "integrity": "sha512-SAeBBCUtdaKtHfZgRD6OH0De/+cKUEuThiErSuFW+sNm/y8m3cUhQH8UqVBPu6HwmqVTEjvZzp/4uhG6lcSZjA==",
+      "deprecated": "This package has been deprecated. Please use @heroui/link instead.",
+      "license": "MIT",
+      "dependencies": {
+        "@nextui-org/react-utils": "2.1.3",
+        "@nextui-org/shared-icons": "2.1.1",
+        "@nextui-org/shared-utils": "2.1.2",
+        "@nextui-org/use-aria-link": "2.2.5",
+        "@react-aria/focus": "3.19.0",
+        "@react-aria/link": "3.7.7",
+        "@react-aria/utils": "3.26.0",
+        "@react-types/link": "3.5.9"
+      },
+      "peerDependencies": {
+        "@nextui-org/system": ">=2.4.0",
+        "@nextui-org/theme": ">=2.4.0",
+        "react": ">=18 || >=19.0.0-rc.0",
+        "react-dom": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@nextui-org/listbox": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@nextui-org/listbox/-/listbox-2.3.9.tgz",
+      "integrity": "sha512-iGJ8xwkXf8K7chk1iZgC05KGpHiWJXY1dnV7ytIJ7yu4BbsRIHb0QknK5j8A74YeGpouJQ9+jsmCERmySxlqlg==",
+      "deprecated": "This package has been deprecated. Please use @heroui/listbox instead.",
+      "license": "MIT",
+      "dependencies": {
+        "@nextui-org/aria-utils": "2.2.7",
+        "@nextui-org/divider": "2.2.5",
+        "@nextui-org/react-utils": "2.1.3",
+        "@nextui-org/shared-utils": "2.1.2",
+        "@nextui-org/use-is-mobile": "2.2.2",
+        "@react-aria/focus": "3.19.0",
+        "@react-aria/interactions": "3.22.5",
+        "@react-aria/listbox": "3.13.6",
+        "@react-aria/utils": "3.26.0",
+        "@react-stately/list": "3.11.1",
+        "@react-types/menu": "3.9.13",
+        "@react-types/shared": "3.26.0",
+        "@tanstack/react-virtual": "3.11.2"
+      },
+      "peerDependencies": {
+        "@nextui-org/system": ">=2.4.0",
+        "@nextui-org/theme": ">=2.4.0",
+        "react": ">=18 || >=19.0.0-rc.0",
+        "react-dom": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@nextui-org/menu": {
+      "version": "2.2.9",
+      "resolved": "https://registry.npmjs.org/@nextui-org/menu/-/menu-2.2.9.tgz",
+      "integrity": "sha512-Fztvi3GRYl5a5FO/0LRzcAdnw8Yeq6NX8yLQh8XmwkWCrH0S6nTn69CP/j+EMWQR6G2UK5AbNDmX1Sx9aTQdHQ==",
+      "deprecated": "This package has been deprecated. Please use @heroui/menu instead.",
+      "license": "MIT",
+      "dependencies": {
+        "@nextui-org/aria-utils": "2.2.7",
+        "@nextui-org/divider": "2.2.5",
+        "@nextui-org/react-utils": "2.1.3",
+        "@nextui-org/shared-utils": "2.1.2",
+        "@nextui-org/use-is-mobile": "2.2.2",
+        "@react-aria/focus": "3.19.0",
+        "@react-aria/interactions": "3.22.5",
+        "@react-aria/menu": "3.16.0",
+        "@react-aria/utils": "3.26.0",
+        "@react-stately/menu": "3.9.0",
+        "@react-stately/tree": "3.8.6",
+        "@react-types/menu": "3.9.13",
+        "@react-types/shared": "3.26.0"
+      },
+      "peerDependencies": {
+        "@nextui-org/system": ">=2.4.0",
+        "@nextui-org/theme": ">=2.4.0",
+        "react": ">=18 || >=19.0.0-rc.0",
+        "react-dom": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@nextui-org/modal": {
+      "version": "2.2.7",
+      "resolved": "https://registry.npmjs.org/@nextui-org/modal/-/modal-2.2.7.tgz",
+      "integrity": "sha512-xxk6B+5s8//qYI4waLjdWoJFwR6Zqym/VHFKkuZAMpNABgTB0FCK022iUdOIP2F2epG69un8zJF0qwMBJF8XAA==",
+      "deprecated": "This package has been deprecated. Please use @heroui/modal instead.",
+      "license": "MIT",
+      "dependencies": {
+        "@nextui-org/dom-animation": "2.1.1",
+        "@nextui-org/framer-utils": "2.1.6",
+        "@nextui-org/react-utils": "2.1.3",
+        "@nextui-org/shared-icons": "2.1.1",
+        "@nextui-org/shared-utils": "2.1.2",
+        "@nextui-org/use-aria-button": "2.2.4",
+        "@nextui-org/use-aria-modal-overlay": "2.2.3",
+        "@nextui-org/use-disclosure": "2.2.2",
+        "@nextui-org/use-draggable": "2.1.2",
+        "@react-aria/dialog": "3.5.20",
+        "@react-aria/focus": "3.19.0",
+        "@react-aria/interactions": "3.22.5",
+        "@react-aria/overlays": "3.24.0",
+        "@react-aria/utils": "3.26.0",
+        "@react-stately/overlays": "3.6.12",
+        "@react-types/overlays": "3.8.11"
+      },
+      "peerDependencies": {
+        "@nextui-org/system": ">=2.4.0",
+        "@nextui-org/theme": ">=2.4.0",
+        "framer-motion": ">=11.5.6 || >=12.0.0-alpha.1",
+        "react": ">=18 || >=19.0.0-rc.0",
+        "react-dom": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@nextui-org/navbar": {
+      "version": "2.2.8",
+      "resolved": "https://registry.npmjs.org/@nextui-org/navbar/-/navbar-2.2.8.tgz",
+      "integrity": "sha512-XutioQ75jonZk6TBtjFdV6N3eLe8y85tetjOdOg6X3mKTPZlQuBb+rtb6pVNOOvcuQ7zKigWIq2ammvF9VNKaQ==",
+      "deprecated": "This package has been deprecated. Please use @heroui/navbar instead.",
+      "license": "MIT",
+      "dependencies": {
+        "@nextui-org/dom-animation": "2.1.1",
+        "@nextui-org/framer-utils": "2.1.6",
+        "@nextui-org/react-utils": "2.1.3",
+        "@nextui-org/shared-utils": "2.1.2",
+        "@nextui-org/use-scroll-position": "2.1.1",
+        "@react-aria/button": "3.11.0",
+        "@react-aria/focus": "3.19.0",
+        "@react-aria/interactions": "3.22.5",
+        "@react-aria/overlays": "3.24.0",
+        "@react-aria/utils": "3.26.0",
+        "@react-stately/toggle": "3.8.0",
+        "@react-stately/utils": "3.10.5"
+      },
+      "peerDependencies": {
+        "@nextui-org/system": ">=2.4.0",
+        "@nextui-org/theme": ">=2.4.0",
+        "framer-motion": ">=11.5.6 || >=12.0.0-alpha.1",
+        "react": ">=18 || >=19.0.0-rc.0",
+        "react-dom": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@nextui-org/pagination": {
+      "version": "2.2.8",
+      "resolved": "https://registry.npmjs.org/@nextui-org/pagination/-/pagination-2.2.8.tgz",
+      "integrity": "sha512-sZcriQq/ssOItX3r54tysnItjcb7dw392BNulJxrMMXi6FA6sUGImpJF1jsbtYJvaq346IoZvMrcrba8PXEk0g==",
+      "deprecated": "This package has been deprecated. Please use @heroui/pagination instead.",
+      "license": "MIT",
+      "dependencies": {
+        "@nextui-org/react-utils": "2.1.3",
+        "@nextui-org/shared-icons": "2.1.1",
+        "@nextui-org/shared-utils": "2.1.2",
+        "@nextui-org/use-intersection-observer": "2.2.2",
+        "@nextui-org/use-pagination": "2.2.3",
+        "@react-aria/focus": "3.19.0",
+        "@react-aria/i18n": "3.12.4",
+        "@react-aria/interactions": "3.22.5",
+        "@react-aria/utils": "3.26.0",
+        "scroll-into-view-if-needed": "3.0.10"
+      },
+      "peerDependencies": {
+        "@nextui-org/system": ">=2.4.0",
+        "@nextui-org/theme": ">=2.4.0",
+        "react": ">=18 || >=19.0.0-rc.0",
+        "react-dom": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@nextui-org/popover": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@nextui-org/popover/-/popover-2.3.9.tgz",
+      "integrity": "sha512-glLYKlFJ4EkFrNMBC3ediFPpQwKzaFlzKoaMum2G3HUtmC4d1HLTSOQJOd2scUzZxD3/K9dp1XHYbEcCnCrYpQ==",
+      "deprecated": "This package has been deprecated. Please use @heroui/popover instead.",
+      "license": "MIT",
+      "dependencies": {
+        "@nextui-org/aria-utils": "2.2.7",
+        "@nextui-org/button": "2.2.9",
+        "@nextui-org/dom-animation": "2.1.1",
+        "@nextui-org/framer-utils": "2.1.6",
+        "@nextui-org/react-utils": "2.1.3",
+        "@nextui-org/shared-utils": "2.1.2",
+        "@nextui-org/use-aria-button": "2.2.4",
+        "@nextui-org/use-safe-layout-effect": "2.1.1",
+        "@react-aria/dialog": "3.5.20",
+        "@react-aria/focus": "3.19.0",
+        "@react-aria/interactions": "3.22.5",
+        "@react-aria/overlays": "3.24.0",
+        "@react-aria/utils": "3.26.0",
+        "@react-stately/overlays": "3.6.12",
+        "@react-types/button": "3.10.1",
+        "@react-types/overlays": "3.8.11"
+      },
+      "peerDependencies": {
+        "@nextui-org/system": ">=2.4.0",
+        "@nextui-org/theme": ">=2.4.0",
+        "framer-motion": ">=11.5.6 || >=12.0.0-alpha.1",
+        "react": ">=18 || >=19.0.0-rc.0",
+        "react-dom": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@nextui-org/progress": {
+      "version": "2.2.6",
+      "resolved": "https://registry.npmjs.org/@nextui-org/progress/-/progress-2.2.6.tgz",
+      "integrity": "sha512-FTicOncNcXKpt9avxQWWlVATvhABKVMBgsB81SozFXRcn8QsFntjdMp0l3688DJKBY0GxT+yl/S/by0TwY1Z1A==",
+      "deprecated": "This package has been deprecated. Please use @heroui/progress instead.",
+      "license": "MIT",
+      "dependencies": {
+        "@nextui-org/react-utils": "2.1.3",
+        "@nextui-org/shared-utils": "2.1.2",
+        "@nextui-org/use-is-mounted": "2.1.1",
+        "@react-aria/i18n": "3.12.4",
+        "@react-aria/progress": "3.4.18",
+        "@react-aria/utils": "3.26.0",
+        "@react-types/progress": "3.5.8"
+      },
+      "peerDependencies": {
+        "@nextui-org/system": ">=2.4.0",
+        "@nextui-org/theme": ">=2.4.0",
+        "react": ">=18 || >=19.0.0-rc.0",
+        "react-dom": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@nextui-org/radio": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/@nextui-org/radio/-/radio-2.3.8.tgz",
+      "integrity": "sha512-ntwjpQ/WT8zQ3Fw5io65VeH2Q68LOgZ4lII7a6x35NDa7Eda1vlYroMAw/vxK8iyZYlUBSJdsoj2FU/10hBPmg==",
+      "deprecated": "This package has been deprecated. Please use @heroui/radio instead.",
+      "license": "MIT",
+      "dependencies": {
+        "@nextui-org/form": "2.1.8",
+        "@nextui-org/react-utils": "2.1.3",
+        "@nextui-org/shared-utils": "2.1.2",
+        "@react-aria/focus": "3.19.0",
+        "@react-aria/interactions": "3.22.5",
+        "@react-aria/radio": "3.10.10",
+        "@react-aria/utils": "3.26.0",
+        "@react-aria/visually-hidden": "3.8.18",
+        "@react-stately/radio": "3.10.9",
+        "@react-types/radio": "3.8.5",
+        "@react-types/shared": "3.26.0"
+      },
+      "peerDependencies": {
+        "@nextui-org/system": ">=2.4.0",
+        "@nextui-org/theme": ">=2.4.3",
+        "react": ">=18 || >=19.0.0-rc.0",
+        "react-dom": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@nextui-org/react": {
+      "version": "2.6.11",
+      "resolved": "https://registry.npmjs.org/@nextui-org/react/-/react-2.6.11.tgz",
+      "integrity": "sha512-MOkBMWI+1nHB6A8YLXakdXrNRFvy5whjFJB1FthwqbP8pVEeksS1e29AbfEFkrzLc5zjN7i24wGNSJ8DKMt9WQ==",
+      "deprecated": "This package has been deprecated. Please use @heroui/react instead.",
+      "license": "MIT",
+      "dependencies": {
+        "@nextui-org/accordion": "2.2.7",
+        "@nextui-org/alert": "2.2.9",
+        "@nextui-org/autocomplete": "2.3.9",
+        "@nextui-org/avatar": "2.2.6",
+        "@nextui-org/badge": "2.2.5",
+        "@nextui-org/breadcrumbs": "2.2.6",
+        "@nextui-org/button": "2.2.9",
+        "@nextui-org/calendar": "2.2.9",
+        "@nextui-org/card": "2.2.9",
+        "@nextui-org/checkbox": "2.3.8",
+        "@nextui-org/chip": "2.2.6",
+        "@nextui-org/code": "2.2.6",
+        "@nextui-org/date-input": "2.3.8",
+        "@nextui-org/date-picker": "2.3.9",
+        "@nextui-org/divider": "2.2.5",
+        "@nextui-org/drawer": "2.2.7",
+        "@nextui-org/dropdown": "2.3.9",
+        "@nextui-org/form": "2.1.8",
+        "@nextui-org/framer-utils": "2.1.6",
+        "@nextui-org/image": "2.2.5",
+        "@nextui-org/input": "2.4.8",
+        "@nextui-org/input-otp": "2.1.8",
+        "@nextui-org/kbd": "2.2.6",
+        "@nextui-org/link": "2.2.7",
+        "@nextui-org/listbox": "2.3.9",
+        "@nextui-org/menu": "2.2.9",
+        "@nextui-org/modal": "2.2.7",
+        "@nextui-org/navbar": "2.2.8",
+        "@nextui-org/pagination": "2.2.8",
+        "@nextui-org/popover": "2.3.9",
+        "@nextui-org/progress": "2.2.6",
+        "@nextui-org/radio": "2.3.8",
+        "@nextui-org/ripple": "2.2.7",
+        "@nextui-org/scroll-shadow": "2.3.5",
+        "@nextui-org/select": "2.4.9",
+        "@nextui-org/skeleton": "2.2.5",
+        "@nextui-org/slider": "2.4.7",
+        "@nextui-org/snippet": "2.2.10",
+        "@nextui-org/spacer": "2.2.6",
+        "@nextui-org/spinner": "2.2.6",
+        "@nextui-org/switch": "2.2.8",
+        "@nextui-org/system": "2.4.6",
+        "@nextui-org/table": "2.2.8",
+        "@nextui-org/tabs": "2.2.7",
+        "@nextui-org/theme": "2.4.5",
+        "@nextui-org/tooltip": "2.2.7",
+        "@nextui-org/user": "2.2.6",
+        "@react-aria/visually-hidden": "3.8.18"
+      },
+      "peerDependencies": {
+        "framer-motion": ">=11.5.6 || >=12.0.0-alpha.1",
+        "react": ">=18 || >=19.0.0-rc.0",
+        "react-dom": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@nextui-org/react-rsc-utils": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@nextui-org/react-rsc-utils/-/react-rsc-utils-2.1.1.tgz",
+      "integrity": "sha512-9uKH1XkeomTGaswqlGKt0V0ooUev8mPXtKJolR+6MnpvBUrkqngw1gUGF0bq/EcCCkks2+VOHXZqFT6x9hGkQQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@nextui-org/react-utils": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@nextui-org/react-utils/-/react-utils-2.1.3.tgz",
+      "integrity": "sha512-o61fOS+S8p3KtgLLN7ub5gR0y7l517l9eZXJabUdnVcZzZjTqEijWjzjIIIyAtYAlL4d+WTXEOROuc32sCmbqw==",
+      "license": "MIT",
+      "dependencies": {
+        "@nextui-org/react-rsc-utils": "2.1.1",
+        "@nextui-org/shared-utils": "2.1.2"
+      },
+      "peerDependencies": {
+        "react": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@nextui-org/ripple": {
+      "version": "2.2.7",
+      "resolved": "https://registry.npmjs.org/@nextui-org/ripple/-/ripple-2.2.7.tgz",
+      "integrity": "sha512-cphzlvCjdROh1JWQhO/wAsmBdlU9kv/UA2YRQS4viaWcA3zO+qOZVZ9/YZMan6LBlOLENCaE9CtV2qlzFtVpEg==",
+      "deprecated": "This package has been deprecated. Please use @heroui/ripple instead.",
+      "license": "MIT",
+      "dependencies": {
+        "@nextui-org/dom-animation": "2.1.1",
+        "@nextui-org/react-utils": "2.1.3",
+        "@nextui-org/shared-utils": "2.1.2"
+      },
+      "peerDependencies": {
+        "@nextui-org/system": ">=2.4.0",
+        "@nextui-org/theme": ">=2.4.0",
+        "framer-motion": ">=11.5.6 || >=12.0.0-alpha.1",
+        "react": ">=18 || >=19.0.0-rc.0",
+        "react-dom": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@nextui-org/scroll-shadow": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@nextui-org/scroll-shadow/-/scroll-shadow-2.3.5.tgz",
+      "integrity": "sha512-2H5qro6RHcWo6ZfcG2hHZHsR1LrV3FMZP5Lkc9ZwJdWPg4dXY4erGRE4U+B7me6efj5tBOFmZkIpxVUyMBLtZg==",
+      "deprecated": "This package has been deprecated. Please use @heroui/scroll-shadow instead.",
+      "license": "MIT",
+      "dependencies": {
+        "@nextui-org/react-utils": "2.1.3",
+        "@nextui-org/shared-utils": "2.1.2",
+        "@nextui-org/use-data-scroll-overflow": "2.2.2"
+      },
+      "peerDependencies": {
+        "@nextui-org/system": ">=2.4.0",
+        "@nextui-org/theme": ">=2.4.0",
+        "react": ">=18 || >=19.0.0-rc.0",
+        "react-dom": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@nextui-org/select": {
+      "version": "2.4.9",
+      "resolved": "https://registry.npmjs.org/@nextui-org/select/-/select-2.4.9.tgz",
+      "integrity": "sha512-R8HHKDH7dA4Dv73Pl80X7qfqdyl+Fw4gi/9bmyby0QJG8LN2zu51xyjjKphmWVkAiE3O35BRVw7vMptHnWFUgQ==",
+      "deprecated": "This package has been deprecated. Please use @heroui/select instead.",
+      "license": "MIT",
+      "dependencies": {
+        "@nextui-org/aria-utils": "2.2.7",
+        "@nextui-org/form": "2.1.8",
+        "@nextui-org/listbox": "2.3.9",
+        "@nextui-org/popover": "2.3.9",
+        "@nextui-org/react-utils": "2.1.3",
+        "@nextui-org/scroll-shadow": "2.3.5",
+        "@nextui-org/shared-icons": "2.1.1",
+        "@nextui-org/shared-utils": "2.1.2",
+        "@nextui-org/spinner": "2.2.6",
+        "@nextui-org/use-aria-button": "2.2.4",
+        "@nextui-org/use-aria-multiselect": "2.4.3",
+        "@nextui-org/use-safe-layout-effect": "2.1.1",
+        "@react-aria/focus": "3.19.0",
+        "@react-aria/form": "3.0.11",
+        "@react-aria/interactions": "3.22.5",
+        "@react-aria/utils": "3.26.0",
+        "@react-aria/visually-hidden": "3.8.18",
+        "@react-types/shared": "3.26.0",
+        "@tanstack/react-virtual": "3.11.2"
+      },
+      "peerDependencies": {
+        "@nextui-org/system": ">=2.4.0",
+        "@nextui-org/theme": ">=2.4.0",
+        "framer-motion": ">=11.5.6 || >=12.0.0-alpha.1",
+        "react": ">=18 || >=19.0.0-rc.0",
+        "react-dom": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@nextui-org/shared-icons": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@nextui-org/shared-icons/-/shared-icons-2.1.1.tgz",
+      "integrity": "sha512-mkiTpFJnCzB2M8Dl7IwXVzDKKq9ZW2WC0DaQRs1eWgqboRCP8DDde+MJZq331hC7pfH8BC/4rxXsKECrOUUwCg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@nextui-org/shared-utils": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@nextui-org/shared-utils/-/shared-utils-2.1.2.tgz",
+      "integrity": "sha512-5n0D+AGB4P9lMD1TxwtdRSuSY0cWgyXKO9mMU11Xl3zoHNiAz/SbCSTc4VBJdQJ7Y3qgNXvZICzf08+bnjjqqA==",
+      "license": "MIT"
+    },
+    "node_modules/@nextui-org/skeleton": {
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/@nextui-org/skeleton/-/skeleton-2.2.5.tgz",
+      "integrity": "sha512-CK1O9dqS0xPW3o1SIekEEOjSosJkXNzU0Zd538Nn1XhY1RjNuIPchpY9Pv5YZr2QSKy0zkwPQt/NalwErke0Jg==",
+      "deprecated": "This package has been deprecated. Please use @heroui/skeleton instead.",
+      "license": "MIT",
+      "dependencies": {
+        "@nextui-org/react-utils": "2.1.3",
+        "@nextui-org/shared-utils": "2.1.2"
+      },
+      "peerDependencies": {
+        "@nextui-org/system": ">=2.4.0",
+        "@nextui-org/theme": ">=2.4.0",
+        "react": ">=18 || >=19.0.0-rc.0",
+        "react-dom": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@nextui-org/slider": {
+      "version": "2.4.7",
+      "resolved": "https://registry.npmjs.org/@nextui-org/slider/-/slider-2.4.7.tgz",
+      "integrity": "sha512-/RnjnmAPvssebhtElG+ZI8CCot2dEBcEjw7LrHfmVnJOd5jgceMtnXhdJSppQuLvcC4fPpkhd6dY86IezOZwfw==",
+      "deprecated": "This package has been deprecated. Please use @heroui/slider instead.",
+      "license": "MIT",
+      "dependencies": {
+        "@nextui-org/react-utils": "2.1.3",
+        "@nextui-org/shared-utils": "2.1.2",
+        "@nextui-org/tooltip": "2.2.7",
+        "@react-aria/focus": "3.19.0",
+        "@react-aria/i18n": "3.12.4",
+        "@react-aria/interactions": "3.22.5",
+        "@react-aria/slider": "3.7.14",
+        "@react-aria/utils": "3.26.0",
+        "@react-aria/visually-hidden": "3.8.18",
+        "@react-stately/slider": "3.6.0"
+      },
+      "peerDependencies": {
+        "@nextui-org/system": ">=2.4.0",
+        "@nextui-org/theme": ">=2.4.0",
+        "react": ">=18 || >=19.0.0-rc.0",
+        "react-dom": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@nextui-org/snippet": {
+      "version": "2.2.10",
+      "resolved": "https://registry.npmjs.org/@nextui-org/snippet/-/snippet-2.2.10.tgz",
+      "integrity": "sha512-mVjf8muq4TX2PlESN7EeHgFmjuz7PNhrKFP+fb8Lj9J6wvUIUDm5ENv9bs72cRsK+zse6OUNE4JF1er6HllKug==",
+      "deprecated": "This package has been deprecated. Please use @heroui/snippet instead.",
+      "license": "MIT",
+      "dependencies": {
+        "@nextui-org/button": "2.2.9",
+        "@nextui-org/react-utils": "2.1.3",
+        "@nextui-org/shared-icons": "2.1.1",
+        "@nextui-org/shared-utils": "2.1.2",
+        "@nextui-org/tooltip": "2.2.7",
+        "@nextui-org/use-clipboard": "2.1.2",
+        "@react-aria/focus": "3.19.0",
+        "@react-aria/utils": "3.26.0"
+      },
+      "peerDependencies": {
+        "@nextui-org/system": ">=2.4.0",
+        "@nextui-org/theme": ">=2.4.0",
+        "framer-motion": ">=11.5.6 || >=12.0.0-alpha.1",
+        "react": ">=18 || >=19.0.0-rc.0",
+        "react-dom": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@nextui-org/spacer": {
+      "version": "2.2.6",
+      "resolved": "https://registry.npmjs.org/@nextui-org/spacer/-/spacer-2.2.6.tgz",
+      "integrity": "sha512-1qYtZ6xICfSrFV0MMB/nUH1K2X9mHzIikrjC/okzyzWywibsVNbyRfu5vObVClYlVGY0r4M4+7fpV2QV1tKRGw==",
+      "deprecated": "This package has been deprecated. Please use @heroui/spacer instead.",
+      "license": "MIT",
+      "dependencies": {
+        "@nextui-org/react-utils": "2.1.3",
+        "@nextui-org/shared-utils": "2.1.2",
+        "@nextui-org/system-rsc": "2.3.5"
+      },
+      "peerDependencies": {
+        "@nextui-org/theme": ">=2.4.0",
+        "react": ">=18 || >=19.0.0-rc.0",
+        "react-dom": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@nextui-org/spinner": {
+      "version": "2.2.6",
+      "resolved": "https://registry.npmjs.org/@nextui-org/spinner/-/spinner-2.2.6.tgz",
+      "integrity": "sha512-0V0H8jVpgRolgLnCuKDbrQCSK0VFPAZYiyGOE1+dfyIezpta+Nglh+uEl2sEFNh6B9Z8mARB8YEpRnTcA0ePDw==",
+      "deprecated": "This package has been deprecated. Please use @heroui/spinner instead.",
+      "license": "MIT",
+      "dependencies": {
+        "@nextui-org/react-utils": "2.1.3",
+        "@nextui-org/shared-utils": "2.1.2",
+        "@nextui-org/system-rsc": "2.3.5"
+      },
+      "peerDependencies": {
+        "@nextui-org/theme": ">=2.4.0",
+        "react": ">=18 || >=19.0.0-rc.0",
+        "react-dom": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@nextui-org/switch": {
+      "version": "2.2.8",
+      "resolved": "https://registry.npmjs.org/@nextui-org/switch/-/switch-2.2.8.tgz",
+      "integrity": "sha512-wk9qQSOfUEtmdWR1omKjmEYzgMjJhVizvfW6Z0rKOiMUuSud2d4xYnUmZhU22cv2WtoPV//kBjXkYD/E/t6rdg==",
+      "deprecated": "This package has been deprecated. Please use @heroui/switch instead.",
+      "license": "MIT",
+      "dependencies": {
+        "@nextui-org/react-utils": "2.1.3",
+        "@nextui-org/shared-utils": "2.1.2",
+        "@nextui-org/use-safe-layout-effect": "2.1.1",
+        "@react-aria/focus": "3.19.0",
+        "@react-aria/interactions": "3.22.5",
+        "@react-aria/switch": "3.6.10",
+        "@react-aria/utils": "3.26.0",
+        "@react-aria/visually-hidden": "3.8.18",
+        "@react-stately/toggle": "3.8.0",
+        "@react-types/shared": "3.26.0"
+      },
+      "peerDependencies": {
+        "@nextui-org/system": ">=2.4.0",
+        "@nextui-org/theme": ">=2.4.3",
+        "react": ">=18 || >=19.0.0-rc.0",
+        "react-dom": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@nextui-org/system": {
+      "version": "2.4.6",
+      "resolved": "https://registry.npmjs.org/@nextui-org/system/-/system-2.4.6.tgz",
+      "integrity": "sha512-6ujAriBZMfQ16n6M6Ad9g32KJUa1CzqIVaHN/tymadr/3m8hrr7xDw6z50pVjpCRq2PaaA1hT8Hx7EFU3f2z3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@internationalized/date": "3.6.0",
+        "@nextui-org/react-utils": "2.1.3",
+        "@nextui-org/system-rsc": "2.3.5",
+        "@react-aria/i18n": "3.12.4",
+        "@react-aria/overlays": "3.24.0",
+        "@react-aria/utils": "3.26.0",
+        "@react-stately/utils": "3.10.5",
+        "@react-types/datepicker": "3.9.0"
+      },
+      "peerDependencies": {
+        "framer-motion": ">=11.5.6 || >=12.0.0-alpha.1",
+        "react": ">=18 || >=19.0.0-rc.0",
+        "react-dom": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@nextui-org/system-rsc": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@nextui-org/system-rsc/-/system-rsc-2.3.5.tgz",
+      "integrity": "sha512-DpVLNV9LkeP1yDULFCXm2mxA9m4ygS7XYy3lwgcF9M1A8QAWB+ut+FcP+8a6va50oSHOqwvUwPDUslgXTPMBfQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-types/shared": "3.26.0",
+        "clsx": "^1.2.1"
+      },
+      "peerDependencies": {
+        "@nextui-org/theme": ">=2.4.0",
+        "react": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@nextui-org/table": {
+      "version": "2.2.8",
+      "resolved": "https://registry.npmjs.org/@nextui-org/table/-/table-2.2.8.tgz",
+      "integrity": "sha512-XNM0/Ed7Re3BA1eHL31rzALea9hgsBwD0rMR2qB2SAl2e8KaV2o+4bzgYhpISAzHQtlG8IsXanxiuNDH8OPVyw==",
+      "deprecated": "This package has been deprecated. Please use @heroui/table instead.",
+      "license": "MIT",
+      "dependencies": {
+        "@nextui-org/checkbox": "2.3.8",
+        "@nextui-org/react-utils": "2.1.3",
+        "@nextui-org/shared-icons": "2.1.1",
+        "@nextui-org/shared-utils": "2.1.2",
+        "@nextui-org/spacer": "2.2.6",
+        "@react-aria/focus": "3.19.0",
+        "@react-aria/interactions": "3.22.5",
+        "@react-aria/table": "3.16.0",
+        "@react-aria/utils": "3.26.0",
+        "@react-aria/visually-hidden": "3.8.18",
+        "@react-stately/table": "3.13.0",
+        "@react-stately/virtualizer": "4.2.0",
+        "@react-types/grid": "3.2.10",
+        "@react-types/table": "3.10.3"
+      },
+      "peerDependencies": {
+        "@nextui-org/system": ">=2.4.0",
+        "@nextui-org/theme": ">=2.4.0",
+        "react": ">=18 || >=19.0.0-rc.0",
+        "react-dom": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@nextui-org/tabs": {
+      "version": "2.2.7",
+      "resolved": "https://registry.npmjs.org/@nextui-org/tabs/-/tabs-2.2.7.tgz",
+      "integrity": "sha512-EDPK0MOR4DPTfud9Khr5AikLbyEhHTlkGfazbOxg7wFaHysOnV5Y/E6UfvaN69kgIeT7NQcDFdaCKJ/AX1N7AA==",
+      "deprecated": "This package has been deprecated. Please use @heroui/tabs instead.",
+      "license": "MIT",
+      "dependencies": {
+        "@nextui-org/aria-utils": "2.2.7",
+        "@nextui-org/framer-utils": "2.1.6",
+        "@nextui-org/react-utils": "2.1.3",
+        "@nextui-org/shared-utils": "2.1.2",
+        "@nextui-org/use-is-mounted": "2.1.1",
+        "@nextui-org/use-update-effect": "2.1.1",
+        "@react-aria/focus": "3.19.0",
+        "@react-aria/interactions": "3.22.5",
+        "@react-aria/tabs": "3.9.8",
+        "@react-aria/utils": "3.26.0",
+        "@react-stately/tabs": "3.7.0",
+        "@react-types/shared": "3.26.0",
+        "@react-types/tabs": "3.3.11",
+        "scroll-into-view-if-needed": "3.0.10"
+      },
+      "peerDependencies": {
+        "@nextui-org/system": ">=2.4.0",
+        "@nextui-org/theme": ">=2.4.0",
+        "framer-motion": ">=11.5.6 || >=12.0.0-alpha.1",
+        "react": ">=18 || >=19.0.0-rc.0",
+        "react-dom": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@nextui-org/theme": {
+      "version": "2.4.5",
+      "resolved": "https://registry.npmjs.org/@nextui-org/theme/-/theme-2.4.5.tgz",
+      "integrity": "sha512-c7Y17n+hBGiFedxMKfg7Qyv93iY5MteamLXV4Po4c1VF1qZJI6I+IKULFh3FxPWzAoz96r6NdYT7OLFjrAJdWg==",
+      "license": "MIT",
+      "dependencies": {
+        "@nextui-org/shared-utils": "2.1.2",
+        "clsx": "^1.2.1",
+        "color": "^4.2.3",
+        "color2k": "^2.0.2",
+        "deepmerge": "4.3.1",
+        "flat": "^5.0.2",
+        "tailwind-merge": "^2.5.2",
+        "tailwind-variants": "^0.1.20"
+      },
+      "peerDependencies": {
+        "tailwindcss": ">=3.4.0"
+      }
+    },
+    "node_modules/@nextui-org/tooltip": {
+      "version": "2.2.7",
+      "resolved": "https://registry.npmjs.org/@nextui-org/tooltip/-/tooltip-2.2.7.tgz",
+      "integrity": "sha512-NgoaxcNwuCq/jvp77dmGzyS7JxzX4dvD/lAYi/GUhyxEC3TK3teZ3ADRhrC6tb84OpaelPLaTkhRNSaxVAQzjQ==",
+      "deprecated": "This package has been deprecated. Please use @heroui/tooltip instead.",
+      "license": "MIT",
+      "dependencies": {
+        "@nextui-org/aria-utils": "2.2.7",
+        "@nextui-org/dom-animation": "2.1.1",
+        "@nextui-org/framer-utils": "2.1.6",
+        "@nextui-org/react-utils": "2.1.3",
+        "@nextui-org/shared-utils": "2.1.2",
+        "@nextui-org/use-safe-layout-effect": "2.1.1",
+        "@react-aria/interactions": "3.22.5",
+        "@react-aria/overlays": "3.24.0",
+        "@react-aria/tooltip": "3.7.10",
+        "@react-aria/utils": "3.26.0",
+        "@react-stately/tooltip": "3.5.0",
+        "@react-types/overlays": "3.8.11",
+        "@react-types/tooltip": "3.4.13"
+      },
+      "peerDependencies": {
+        "@nextui-org/system": ">=2.4.0",
+        "@nextui-org/theme": ">=2.4.0",
+        "framer-motion": ">=11.5.6 || >=12.0.0-alpha.1",
+        "react": ">=18 || >=19.0.0-rc.0",
+        "react-dom": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@nextui-org/use-aria-accordion": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@nextui-org/use-aria-accordion/-/use-aria-accordion-2.2.2.tgz",
+      "integrity": "sha512-M8gjX6XmB83cIAZKV2zI1KvmTuuOh+Si50F3SWvYjBXyrDIM5775xCs2PG6AcLjf6OONTl5KwuZ2cbSDHiui6A==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-aria/button": "3.11.0",
+        "@react-aria/focus": "3.19.0",
+        "@react-aria/selection": "3.21.0",
+        "@react-aria/utils": "3.26.0",
+        "@react-stately/tree": "3.8.6",
+        "@react-types/accordion": "3.0.0-alpha.25",
+        "@react-types/shared": "3.26.0"
+      },
+      "peerDependencies": {
+        "react": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@nextui-org/use-aria-button": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/@nextui-org/use-aria-button/-/use-aria-button-2.2.4.tgz",
+      "integrity": "sha512-Bz8l4JGzRKh6V58VX8Laq4rKZDppsnVuNCBHpMJuLo2F9ht7UKvZAEJwXcdbUZ87aui/ZC+IPYqgjvT+d8QlQg==",
+      "license": "MIT",
+      "dependencies": {
+        "@nextui-org/shared-utils": "2.1.2",
+        "@react-aria/focus": "3.19.0",
+        "@react-aria/interactions": "3.22.5",
+        "@react-aria/utils": "3.26.0",
+        "@react-types/button": "3.10.1",
+        "@react-types/shared": "3.26.0"
+      },
+      "peerDependencies": {
+        "react": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@nextui-org/use-aria-link": {
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/@nextui-org/use-aria-link/-/use-aria-link-2.2.5.tgz",
+      "integrity": "sha512-LBWXLecvuET4ZcpoHyyuS3yxvCzXdkmFcODhYwUmC8PiFSEUHkuFMC+fLwdXCP5GOqrv6wTGYHf41wNy1ugX1w==",
+      "license": "MIT",
+      "dependencies": {
+        "@nextui-org/shared-utils": "2.1.2",
+        "@react-aria/focus": "3.19.0",
+        "@react-aria/interactions": "3.22.5",
+        "@react-aria/utils": "3.26.0",
+        "@react-types/link": "3.5.9",
+        "@react-types/shared": "3.26.0"
+      },
+      "peerDependencies": {
+        "react": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@nextui-org/use-aria-modal-overlay": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/@nextui-org/use-aria-modal-overlay/-/use-aria-modal-overlay-2.2.3.tgz",
+      "integrity": "sha512-55DIVY0u+Ynxy1/DtzZkMsdVW63wC0mafKXACwCi0xV64D0Ggi9MM7BRePLK0mOboSb3gjCwYqn12gmRiy+kmg==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-aria/overlays": "3.24.0",
+        "@react-aria/utils": "3.26.0",
+        "@react-stately/overlays": "3.6.12",
+        "@react-types/shared": "3.26.0"
+      },
+      "peerDependencies": {
+        "react": ">=18 || >=19.0.0-rc.0",
+        "react-dom": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@nextui-org/use-aria-multiselect": {
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/@nextui-org/use-aria-multiselect/-/use-aria-multiselect-2.4.3.tgz",
+      "integrity": "sha512-PwDA4Y5DOx0SMxc277JeZi8tMtaINTwthPhk8SaDrtOBhP+r9owS3T/W9t37xKnmrTerHwaEq4ADGQtm5/VMXQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-aria/i18n": "3.12.4",
+        "@react-aria/interactions": "3.22.5",
+        "@react-aria/label": "3.7.13",
+        "@react-aria/listbox": "3.13.6",
+        "@react-aria/menu": "3.16.0",
+        "@react-aria/selection": "3.21.0",
+        "@react-aria/utils": "3.26.0",
+        "@react-stately/form": "3.1.0",
+        "@react-stately/list": "3.11.1",
+        "@react-stately/menu": "3.9.0",
+        "@react-types/button": "3.10.1",
+        "@react-types/overlays": "3.8.11",
+        "@react-types/select": "3.9.8",
+        "@react-types/shared": "3.26.0"
+      },
+      "peerDependencies": {
+        "react": ">=18 || >=19.0.0-rc.0",
+        "react-dom": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@nextui-org/use-callback-ref": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@nextui-org/use-callback-ref/-/use-callback-ref-2.1.1.tgz",
+      "integrity": "sha512-DzlKJ9p7Tm0x3HGjynZ/CgS1jfoBILXKFXnYPLr/SSETXqVaCguixolT/07BRB1yo9AGwELaCEt91BeI0Rb6hQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@nextui-org/use-safe-layout-effect": "2.1.1"
+      },
+      "peerDependencies": {
+        "react": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@nextui-org/use-clipboard": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@nextui-org/use-clipboard/-/use-clipboard-2.1.2.tgz",
+      "integrity": "sha512-MUITEPaQAvu9VuMCUQXMc4j3uBgXoD8LVcuuvUVucg/8HK/Xia0dQ4QgK30QlCbZ/BwZ047rgMAgpMZeVKw4MQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@nextui-org/use-data-scroll-overflow": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@nextui-org/use-data-scroll-overflow/-/use-data-scroll-overflow-2.2.2.tgz",
+      "integrity": "sha512-TFB6BuaLOsE++K1UEIPR9StkBgj9Cvvc+ccETYpmn62B7pK44DmxjkwhK0ei59wafJPIyytZ3DgdVDblfSyIXA==",
+      "license": "MIT",
+      "dependencies": {
+        "@nextui-org/shared-utils": "2.1.2"
+      },
+      "peerDependencies": {
+        "react": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@nextui-org/use-disclosure": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@nextui-org/use-disclosure/-/use-disclosure-2.2.2.tgz",
+      "integrity": "sha512-ka+5Fic2MIYtOMHi3zomtkWxCWydmJmcq7+fb6RHspfr0tGYjXWYO/lgtGeHFR1LYksMPLID3c7shT5bqzxJcA==",
+      "license": "MIT",
+      "dependencies": {
+        "@nextui-org/use-callback-ref": "2.1.1",
+        "@react-aria/utils": "3.26.0",
+        "@react-stately/utils": "3.10.5"
+      },
+      "peerDependencies": {
+        "react": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@nextui-org/use-draggable": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@nextui-org/use-draggable/-/use-draggable-2.1.2.tgz",
+      "integrity": "sha512-gN4G42uuRyFlAZ3FgMSeZLBg3LIeGlKTOLRe3JvyaBn1D1mA2+I3XONY1oKd9KKmtYCJNwY/2x6MVsBfy8nsgw==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-aria/interactions": "3.22.5"
+      },
+      "peerDependencies": {
+        "react": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@nextui-org/use-image": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@nextui-org/use-image/-/use-image-2.1.2.tgz",
+      "integrity": "sha512-I46M5gCJK4rZ0qYHPx3kVSF2M2uGaWPwzb3w4Cmx8K9QS+LbUQtRMbD8KOGTHZGA3kBDPvFbAi53Ert4eACrZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@nextui-org/react-utils": "2.1.3",
+        "@nextui-org/use-safe-layout-effect": "2.1.1"
+      },
+      "peerDependencies": {
+        "react": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@nextui-org/use-intersection-observer": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@nextui-org/use-intersection-observer/-/use-intersection-observer-2.2.2.tgz",
+      "integrity": "sha512-fS/4m8jnXO7GYpnp/Lp+7bfBEAXPzqsXgqGK6qrp7sfFEAbLzuJp0fONkbIB3F6F3FJrbFOlY+Y5qrHptO7U/Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-aria/interactions": "3.22.5",
+        "@react-aria/ssr": "3.9.7",
+        "@react-aria/utils": "3.26.0",
+        "@react-types/shared": "3.26.0"
+      },
+      "peerDependencies": {
+        "react": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@nextui-org/use-is-mobile": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@nextui-org/use-is-mobile/-/use-is-mobile-2.2.2.tgz",
+      "integrity": "sha512-gcmUL17fhgGdu8JfXF12FZCGATJIATxV4jSql+FNhR+gc+QRRWBRmCJSpMIE2RvGXL777tDvvoh/tjFMB3pW4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-aria/ssr": "3.9.7"
+      },
+      "peerDependencies": {
+        "react": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@nextui-org/use-is-mounted": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@nextui-org/use-is-mounted/-/use-is-mounted-2.1.1.tgz",
+      "integrity": "sha512-osJB3E/DCu4Le0f+pb21ia9/TaSHwme4r0fHjO5/nUBYk/RCvGlRUUCJClf/wi9WfH8QyjuJ27+zBcUSm6AMMg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@nextui-org/use-measure": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@nextui-org/use-measure/-/use-measure-2.1.1.tgz",
+      "integrity": "sha512-2RVn90gXHTgt6fvzBH4fzgv3hMDz+SEJkqaCTbd6WUNWag4AaLb2WU/65CtLcexyu10HrgYf2xG07ZqtJv0zSg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@nextui-org/use-pagination": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/@nextui-org/use-pagination/-/use-pagination-2.2.3.tgz",
+      "integrity": "sha512-V2WGIq4LLkTpq6EUhJg3MVvHY2ZJ63AYV9N0d52Dc3Qqok0tTRuY51dd1P+F58HyTPW84W2z4q2R8XALtzFxQw==",
+      "license": "MIT",
+      "dependencies": {
+        "@nextui-org/shared-utils": "2.1.2",
+        "@react-aria/i18n": "3.12.4"
+      },
+      "peerDependencies": {
+        "react": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@nextui-org/use-safe-layout-effect": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@nextui-org/use-safe-layout-effect/-/use-safe-layout-effect-2.1.1.tgz",
+      "integrity": "sha512-p0vezi2eujC3rxlMQmCLQlc8CNbp+GQgk6YcSm7Rk10isWVlUII5T1L3y+rcFYdgTPObCkCngPPciNQhD7Lf7g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@nextui-org/use-scroll-position": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@nextui-org/use-scroll-position/-/use-scroll-position-2.1.1.tgz",
+      "integrity": "sha512-RgY1l2POZbSjnEirW51gdb8yNPuQXHqJx3TS8Ut5dk+bhaX9JD3sUdEiJNb3qoHAJInzyjN+27hxnACSlW0gzg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@nextui-org/use-update-effect": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@nextui-org/use-update-effect/-/use-update-effect-2.1.1.tgz",
+      "integrity": "sha512-fKODihHLWcvDk1Sm8xDua9zjdbstxTOw9shB7k/mPkeR3E7SouSpN0+LW67Bczh1EmbRg1pIrFpEOLnbpgMFzA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=18 || >=19.0.0-rc.0"
+      }
+    },
+    "node_modules/@nextui-org/user": {
+      "version": "2.2.6",
+      "resolved": "https://registry.npmjs.org/@nextui-org/user/-/user-2.2.6.tgz",
+      "integrity": "sha512-iimFoP3DVK85p78r0ekC7xpVPQiBIbWnyBPdrnBj1UEgQdKoUzGhVbhYUnA8niBz/AS5xLt6aQixsv9/B0/msw==",
+      "deprecated": "This package has been deprecated. Please use @heroui/user instead.",
+      "license": "MIT",
+      "dependencies": {
+        "@nextui-org/avatar": "2.2.6",
+        "@nextui-org/react-utils": "2.1.3",
+        "@nextui-org/shared-utils": "2.1.2",
+        "@react-aria/focus": "3.19.0",
+        "@react-aria/utils": "3.26.0"
+      },
+      "peerDependencies": {
+        "@nextui-org/system": ">=2.4.0",
+        "@nextui-org/theme": ">=2.4.0",
+        "react": ">=18 || >=19.0.0-rc.0",
+        "react-dom": ">=18 || >=19.0.0-rc.0"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -1248,6 +2878,1896 @@
         "url": "https://github.com/sponsors/panva"
       }
     },
+    "node_modules/@react-aria/breadcrumbs": {
+      "version": "3.5.19",
+      "resolved": "https://registry.npmjs.org/@react-aria/breadcrumbs/-/breadcrumbs-3.5.19.tgz",
+      "integrity": "sha512-mVngOPFYVVhec89rf/CiYQGTfaLRfHFtX+JQwY7sNYNqSA+gO8p4lNARe3Be6bJPgH+LUQuruIY9/ZDL6LT3HA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/i18n": "^3.12.4",
+        "@react-aria/link": "^3.7.7",
+        "@react-aria/utils": "^3.26.0",
+        "@react-types/breadcrumbs": "^3.7.9",
+        "@react-types/shared": "^3.26.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/button": {
+      "version": "3.11.0",
+      "resolved": "https://registry.npmjs.org/@react-aria/button/-/button-3.11.0.tgz",
+      "integrity": "sha512-b37eIV6IW11KmNIAm65F3SEl2/mgj5BrHIysW6smZX3KoKWTGYsYfcQkmtNgY0GOSFfDxMCoolsZ6mxC00nSDA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/focus": "^3.19.0",
+        "@react-aria/interactions": "^3.22.5",
+        "@react-aria/toolbar": "3.0.0-beta.11",
+        "@react-aria/utils": "^3.26.0",
+        "@react-stately/toggle": "^3.8.0",
+        "@react-types/button": "^3.10.1",
+        "@react-types/shared": "^3.26.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/calendar": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@react-aria/calendar/-/calendar-3.6.0.tgz",
+      "integrity": "sha512-tZ3nd5DP8uxckbj83Pt+4RqgcTWDlGi7njzc7QqFOG2ApfnYDUXbIpb/Q4KY6JNlJskG8q33wo0XfOwNy8J+eg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@internationalized/date": "^3.6.0",
+        "@react-aria/i18n": "^3.12.4",
+        "@react-aria/interactions": "^3.22.5",
+        "@react-aria/live-announcer": "^3.4.1",
+        "@react-aria/utils": "^3.26.0",
+        "@react-stately/calendar": "^3.6.0",
+        "@react-types/button": "^3.10.1",
+        "@react-types/calendar": "^3.5.0",
+        "@react-types/shared": "^3.26.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/checkbox": {
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/@react-aria/checkbox/-/checkbox-3.15.0.tgz",
+      "integrity": "sha512-z/8xd4em7o0MroBXwkkwv7QRwiJaA1FwqMhRUb7iqtBGP2oSytBEDf0N7L09oci32a1P4ZPz2rMK5GlLh/PD6g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/form": "^3.0.11",
+        "@react-aria/interactions": "^3.22.5",
+        "@react-aria/label": "^3.7.13",
+        "@react-aria/toggle": "^3.10.10",
+        "@react-aria/utils": "^3.26.0",
+        "@react-stately/checkbox": "^3.6.10",
+        "@react-stately/form": "^3.1.0",
+        "@react-stately/toggle": "^3.8.0",
+        "@react-types/checkbox": "^3.9.0",
+        "@react-types/shared": "^3.26.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/combobox": {
+      "version": "3.11.0",
+      "resolved": "https://registry.npmjs.org/@react-aria/combobox/-/combobox-3.11.0.tgz",
+      "integrity": "sha512-s88YMmPkMO1WSoiH1KIyZDLJqUwvM2wHXXakj3cYw1tBHGo4rOUFq+JWQIbM5EDO4HOR4AUUqzIUd0NO7t3zyg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/i18n": "^3.12.4",
+        "@react-aria/listbox": "^3.13.6",
+        "@react-aria/live-announcer": "^3.4.1",
+        "@react-aria/menu": "^3.16.0",
+        "@react-aria/overlays": "^3.24.0",
+        "@react-aria/selection": "^3.21.0",
+        "@react-aria/textfield": "^3.15.0",
+        "@react-aria/utils": "^3.26.0",
+        "@react-stately/collections": "^3.12.0",
+        "@react-stately/combobox": "^3.10.1",
+        "@react-stately/form": "^3.1.0",
+        "@react-types/button": "^3.10.1",
+        "@react-types/combobox": "^3.13.1",
+        "@react-types/shared": "^3.26.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/datepicker": {
+      "version": "3.12.0",
+      "resolved": "https://registry.npmjs.org/@react-aria/datepicker/-/datepicker-3.12.0.tgz",
+      "integrity": "sha512-VYNXioLfddIHpwQx211+rTYuunDmI7VHWBRetCpH3loIsVFuhFSRchTQpclAzxolO3g0vO7pMVj9VYt7Swp6kg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@internationalized/date": "^3.6.0",
+        "@internationalized/number": "^3.6.0",
+        "@internationalized/string": "^3.2.5",
+        "@react-aria/focus": "^3.19.0",
+        "@react-aria/form": "^3.0.11",
+        "@react-aria/i18n": "^3.12.4",
+        "@react-aria/interactions": "^3.22.5",
+        "@react-aria/label": "^3.7.13",
+        "@react-aria/spinbutton": "^3.6.10",
+        "@react-aria/utils": "^3.26.0",
+        "@react-stately/datepicker": "^3.11.0",
+        "@react-stately/form": "^3.1.0",
+        "@react-types/button": "^3.10.1",
+        "@react-types/calendar": "^3.5.0",
+        "@react-types/datepicker": "^3.9.0",
+        "@react-types/dialog": "^3.5.14",
+        "@react-types/shared": "^3.26.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/dialog": {
+      "version": "3.5.20",
+      "resolved": "https://registry.npmjs.org/@react-aria/dialog/-/dialog-3.5.20.tgz",
+      "integrity": "sha512-l0GZVLgeOd3kL3Yj8xQW7wN3gn9WW3RLd/SGI9t7ciTq+I/FhftjXCWzXLlOCCTLMf+gv7eazecECtmoWUaZWQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/focus": "^3.19.0",
+        "@react-aria/overlays": "^3.24.0",
+        "@react-aria/utils": "^3.26.0",
+        "@react-types/dialog": "^3.5.14",
+        "@react-types/shared": "^3.26.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/focus": {
+      "version": "3.19.0",
+      "resolved": "https://registry.npmjs.org/@react-aria/focus/-/focus-3.19.0.tgz",
+      "integrity": "sha512-hPF9EXoUQeQl1Y21/rbV2H4FdUR2v+4/I0/vB+8U3bT1CJ+1AFj1hc/rqx2DqEwDlEwOHN+E4+mRahQmlybq0A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/interactions": "^3.22.5",
+        "@react-aria/utils": "^3.26.0",
+        "@react-types/shared": "^3.26.0",
+        "@swc/helpers": "^0.5.0",
+        "clsx": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/focus/node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@react-aria/form": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@react-aria/form/-/form-3.0.11.tgz",
+      "integrity": "sha512-oXzjTiwVuuWjZ8muU0hp3BrDH5qjVctLOF50mjPvqUbvXQTHhoDxWweyIXPQjGshaqBd2w4pWaE4A2rG2O/apw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/interactions": "^3.22.5",
+        "@react-aria/utils": "^3.26.0",
+        "@react-stately/form": "^3.1.0",
+        "@react-types/shared": "^3.26.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/grid": {
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/@react-aria/grid/-/grid-3.13.0.tgz",
+      "integrity": "sha512-RcuJYA4fyJ83MH3SunU+P5BGkx3LJdQ6kxwqwWGIuI9eUKc7uVbqvN9WN3fI+L0QfxqBFmh7ffRxIdQn7puuzw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/focus": "^3.20.2",
+        "@react-aria/i18n": "^3.12.8",
+        "@react-aria/interactions": "^3.25.0",
+        "@react-aria/live-announcer": "^3.4.2",
+        "@react-aria/selection": "^3.24.0",
+        "@react-aria/utils": "^3.28.2",
+        "@react-stately/collections": "^3.12.3",
+        "@react-stately/grid": "^3.11.1",
+        "@react-stately/selection": "^3.20.1",
+        "@react-types/checkbox": "^3.9.3",
+        "@react-types/grid": "^3.3.1",
+        "@react-types/shared": "^3.29.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/grid/node_modules/@internationalized/date": {
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/@internationalized/date/-/date-3.8.0.tgz",
+      "integrity": "sha512-J51AJ0fEL68hE4CwGPa6E0PO6JDaVLd8aln48xFCSy7CZkZc96dGEGmLs2OEEbBxcsVZtfrqkXJwI2/MSG8yKw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/helpers": "^0.5.0"
+      }
+    },
+    "node_modules/@react-aria/grid/node_modules/@react-aria/focus": {
+      "version": "3.20.2",
+      "resolved": "https://registry.npmjs.org/@react-aria/focus/-/focus-3.20.2.tgz",
+      "integrity": "sha512-Q3rouk/rzoF/3TuH6FzoAIKrl+kzZi9LHmr8S5EqLAOyP9TXIKG34x2j42dZsAhrw7TbF9gA8tBKwnCNH4ZV+Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/interactions": "^3.25.0",
+        "@react-aria/utils": "^3.28.2",
+        "@react-types/shared": "^3.29.0",
+        "@swc/helpers": "^0.5.0",
+        "clsx": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/grid/node_modules/@react-aria/i18n": {
+      "version": "3.12.8",
+      "resolved": "https://registry.npmjs.org/@react-aria/i18n/-/i18n-3.12.8.tgz",
+      "integrity": "sha512-V/Nau9WuwTwxfFffQL4URyKyY2HhRlu9zmzkF2Hw/j5KmEQemD+9jfaLueG2CJu85lYL06JrZXUdnhZgKnqMkA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@internationalized/date": "^3.8.0",
+        "@internationalized/message": "^3.1.7",
+        "@internationalized/number": "^3.6.1",
+        "@internationalized/string": "^3.2.6",
+        "@react-aria/ssr": "^3.9.8",
+        "@react-aria/utils": "^3.28.2",
+        "@react-types/shared": "^3.29.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/grid/node_modules/@react-aria/interactions": {
+      "version": "3.25.0",
+      "resolved": "https://registry.npmjs.org/@react-aria/interactions/-/interactions-3.25.0.tgz",
+      "integrity": "sha512-GgIsDLlO8rDU/nFn6DfsbP9rfnzhm8QFjZkB9K9+r+MTSCn7bMntiWQgMM+5O6BiA8d7C7x4zuN4bZtc0RBdXQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/ssr": "^3.9.8",
+        "@react-aria/utils": "^3.28.2",
+        "@react-stately/flags": "^3.1.1",
+        "@react-types/shared": "^3.29.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/grid/node_modules/@react-aria/selection": {
+      "version": "3.24.0",
+      "resolved": "https://registry.npmjs.org/@react-aria/selection/-/selection-3.24.0.tgz",
+      "integrity": "sha512-RfGXVc04zz41NVIW89/a3quURZ4LT/GJLkiajQK2VjhisidPdrAWkcfjjWJj0n+tm5gPWbi9Rs5R/Rc8mrvq8Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/focus": "^3.20.2",
+        "@react-aria/i18n": "^3.12.8",
+        "@react-aria/interactions": "^3.25.0",
+        "@react-aria/utils": "^3.28.2",
+        "@react-stately/selection": "^3.20.1",
+        "@react-types/shared": "^3.29.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/grid/node_modules/@react-aria/ssr": {
+      "version": "3.9.8",
+      "resolved": "https://registry.npmjs.org/@react-aria/ssr/-/ssr-3.9.8.tgz",
+      "integrity": "sha512-lQDE/c9uTfBSDOjaZUJS8xP2jCKVk4zjQeIlCH90xaLhHDgbpCdns3xvFpJJujfj3nI4Ll9K7A+ONUBDCASOuw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/helpers": "^0.5.0"
+      },
+      "engines": {
+        "node": ">= 12"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/grid/node_modules/@react-aria/utils": {
+      "version": "3.28.2",
+      "resolved": "https://registry.npmjs.org/@react-aria/utils/-/utils-3.28.2.tgz",
+      "integrity": "sha512-J8CcLbvnQgiBn54eeEvQQbIOfBF3A1QizxMw9P4cl9MkeR03ug7RnjTIdJY/n2p7t59kLeAB3tqiczhcj+Oi5w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/ssr": "^3.9.8",
+        "@react-stately/flags": "^3.1.1",
+        "@react-stately/utils": "^3.10.6",
+        "@react-types/shared": "^3.29.0",
+        "@swc/helpers": "^0.5.0",
+        "clsx": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/grid/node_modules/@react-stately/collections": {
+      "version": "3.12.3",
+      "resolved": "https://registry.npmjs.org/@react-stately/collections/-/collections-3.12.3.tgz",
+      "integrity": "sha512-QfSBME2QWDjUw/RmmUjrYl/j1iCYcYCIDsgZda1OeRtt63R11k0aqmmwrDRwCsA+Sv+D5QgkOp4KK+CokTzoVQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/shared": "^3.29.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/grid/node_modules/@react-stately/utils": {
+      "version": "3.10.6",
+      "resolved": "https://registry.npmjs.org/@react-stately/utils/-/utils-3.10.6.tgz",
+      "integrity": "sha512-O76ip4InfTTzAJrg8OaZxKU4vvjMDOpfA/PGNOytiXwBbkct2ZeZwaimJ8Bt9W1bj5VsZ81/o/tW4BacbdDOMA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/grid/node_modules/@react-types/checkbox": {
+      "version": "3.9.3",
+      "resolved": "https://registry.npmjs.org/@react-types/checkbox/-/checkbox-3.9.3.tgz",
+      "integrity": "sha512-h6wmK7CraKHKE6L13Ut+CtnjRktbMRhkCSorv7eg82M6p4PDhZ7mfDSh13IlGR4sryT8Ka+aOjOU+EvMrKiduA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/shared": "^3.29.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/grid/node_modules/@react-types/grid": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/@react-types/grid/-/grid-3.3.1.tgz",
+      "integrity": "sha512-bPDckheJiHSIzSeSkLqrO6rXRLWvciFJr9rpCjq/+wBj6HsLh2iMpkB/SqmRHTGpPlJvlu0b7AlxK1FYE0QSKA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/shared": "^3.29.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/grid/node_modules/@react-types/shared": {
+      "version": "3.29.0",
+      "resolved": "https://registry.npmjs.org/@react-types/shared/-/shared-3.29.0.tgz",
+      "integrity": "sha512-IDQYu/AHgZimObzCFdNl1LpZvQW/xcfLt3v20sorl5qRucDVj4S9os98sVTZ4IRIBjmS+MkjqpR5E70xan7ooA==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/grid/node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@react-aria/i18n": {
+      "version": "3.12.4",
+      "resolved": "https://registry.npmjs.org/@react-aria/i18n/-/i18n-3.12.4.tgz",
+      "integrity": "sha512-j9+UL3q0Ls8MhXV9gtnKlyozq4aM95YywXqnmJtzT1rYeBx7w28hooqrWkCYLfqr4OIryv1KUnPiCSLwC2OC7w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@internationalized/date": "^3.6.0",
+        "@internationalized/message": "^3.1.6",
+        "@internationalized/number": "^3.6.0",
+        "@internationalized/string": "^3.2.5",
+        "@react-aria/ssr": "^3.9.7",
+        "@react-aria/utils": "^3.26.0",
+        "@react-types/shared": "^3.26.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/interactions": {
+      "version": "3.22.5",
+      "resolved": "https://registry.npmjs.org/@react-aria/interactions/-/interactions-3.22.5.tgz",
+      "integrity": "sha512-kMwiAD9E0TQp+XNnOs13yVJghiy8ET8L0cbkeuTgNI96sOAp/63EJ1FSrDf17iD8sdjt41LafwX/dKXW9nCcLQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/ssr": "^3.9.7",
+        "@react-aria/utils": "^3.26.0",
+        "@react-types/shared": "^3.26.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/label": {
+      "version": "3.7.13",
+      "resolved": "https://registry.npmjs.org/@react-aria/label/-/label-3.7.13.tgz",
+      "integrity": "sha512-brSAXZVTey5RG/Ex6mTrV/9IhGSQFU4Al34qmjEDho+Z2qT4oPwf8k7TRXWWqzOU0ugYxekYbsLd2zlN3XvWcg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/utils": "^3.26.0",
+        "@react-types/shared": "^3.26.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/link": {
+      "version": "3.7.7",
+      "resolved": "https://registry.npmjs.org/@react-aria/link/-/link-3.7.7.tgz",
+      "integrity": "sha512-eVBRcHKhNSsATYWv5wRnZXRqPVcKAWWakyvfrYePIKpC3s4BaHZyTGYdefk8ZwZdEOuQZBqLMnjW80q1uhtkuA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/focus": "^3.19.0",
+        "@react-aria/interactions": "^3.22.5",
+        "@react-aria/utils": "^3.26.0",
+        "@react-types/link": "^3.5.9",
+        "@react-types/shared": "^3.26.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/listbox": {
+      "version": "3.13.6",
+      "resolved": "https://registry.npmjs.org/@react-aria/listbox/-/listbox-3.13.6.tgz",
+      "integrity": "sha512-6hEXEXIZVau9lgBZ4VVjFR3JnGU+fJaPmV3HP0UZ2ucUptfG0MZo24cn+ZQJsWiuaCfNFv5b8qribiv+BcO+Kg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/interactions": "^3.22.5",
+        "@react-aria/label": "^3.7.13",
+        "@react-aria/selection": "^3.21.0",
+        "@react-aria/utils": "^3.26.0",
+        "@react-stately/collections": "^3.12.0",
+        "@react-stately/list": "^3.11.1",
+        "@react-types/listbox": "^3.5.3",
+        "@react-types/shared": "^3.26.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/live-announcer": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/@react-aria/live-announcer/-/live-announcer-3.4.2.tgz",
+      "integrity": "sha512-6+yNF9ZrZ4YJ60Oxy2gKI4/xy6WUv1iePDCFJkgpNVuOEYi8W8czff8ctXu/RPB25OJx5v2sCw9VirRogTo2zA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/helpers": "^0.5.0"
+      }
+    },
+    "node_modules/@react-aria/menu": {
+      "version": "3.16.0",
+      "resolved": "https://registry.npmjs.org/@react-aria/menu/-/menu-3.16.0.tgz",
+      "integrity": "sha512-TNk+Vd3TbpBPUxEloAdHRTaRxf9JBK7YmkHYiq0Yj5Lc22KS0E2eTyhpPM9xJvEWN2TlC5TEvNfdyui2kYWFFQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/focus": "^3.19.0",
+        "@react-aria/i18n": "^3.12.4",
+        "@react-aria/interactions": "^3.22.5",
+        "@react-aria/overlays": "^3.24.0",
+        "@react-aria/selection": "^3.21.0",
+        "@react-aria/utils": "^3.26.0",
+        "@react-stately/collections": "^3.12.0",
+        "@react-stately/menu": "^3.9.0",
+        "@react-stately/selection": "^3.18.0",
+        "@react-stately/tree": "^3.8.6",
+        "@react-types/button": "^3.10.1",
+        "@react-types/menu": "^3.9.13",
+        "@react-types/shared": "^3.26.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/overlays": {
+      "version": "3.24.0",
+      "resolved": "https://registry.npmjs.org/@react-aria/overlays/-/overlays-3.24.0.tgz",
+      "integrity": "sha512-0kAXBsMNTc/a3M07tK9Cdt/ea8CxTAEJ223g8YgqImlmoBBYAL7dl5G01IOj67TM64uWPTmZrOklBchHWgEm3A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/focus": "^3.19.0",
+        "@react-aria/i18n": "^3.12.4",
+        "@react-aria/interactions": "^3.22.5",
+        "@react-aria/ssr": "^3.9.7",
+        "@react-aria/utils": "^3.26.0",
+        "@react-aria/visually-hidden": "^3.8.18",
+        "@react-stately/overlays": "^3.6.12",
+        "@react-types/button": "^3.10.1",
+        "@react-types/overlays": "^3.8.11",
+        "@react-types/shared": "^3.26.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/progress": {
+      "version": "3.4.18",
+      "resolved": "https://registry.npmjs.org/@react-aria/progress/-/progress-3.4.18.tgz",
+      "integrity": "sha512-FOLgJ9t9i1u3oAAimybJG6r7/soNPBnJfWo4Yr6MmaUv90qVGa1h6kiuM5m9H/bm5JobAebhdfHit9lFlgsCmg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/i18n": "^3.12.4",
+        "@react-aria/label": "^3.7.13",
+        "@react-aria/utils": "^3.26.0",
+        "@react-types/progress": "^3.5.8",
+        "@react-types/shared": "^3.26.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/radio": {
+      "version": "3.10.10",
+      "resolved": "https://registry.npmjs.org/@react-aria/radio/-/radio-3.10.10.tgz",
+      "integrity": "sha512-NVdeOVrsrHgSfwL2jWCCXFsWZb+RMRZErj5vthHQW4nkHECGOzeX56VaLWTSvdoCPqi9wdIX8A6K9peeAIgxzA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/focus": "^3.19.0",
+        "@react-aria/form": "^3.0.11",
+        "@react-aria/i18n": "^3.12.4",
+        "@react-aria/interactions": "^3.22.5",
+        "@react-aria/label": "^3.7.13",
+        "@react-aria/utils": "^3.26.0",
+        "@react-stately/radio": "^3.10.9",
+        "@react-types/radio": "^3.8.5",
+        "@react-types/shared": "^3.26.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/selection": {
+      "version": "3.21.0",
+      "resolved": "https://registry.npmjs.org/@react-aria/selection/-/selection-3.21.0.tgz",
+      "integrity": "sha512-52JJ6hlPcM+gt0VV3DBmz6Kj1YAJr13TfutrKfGWcK36LvNCBm1j0N+TDqbdnlp8Nue6w0+5FIwZq44XPYiBGg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/focus": "^3.19.0",
+        "@react-aria/i18n": "^3.12.4",
+        "@react-aria/interactions": "^3.22.5",
+        "@react-aria/utils": "^3.26.0",
+        "@react-stately/selection": "^3.18.0",
+        "@react-types/shared": "^3.26.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/slider": {
+      "version": "3.7.14",
+      "resolved": "https://registry.npmjs.org/@react-aria/slider/-/slider-3.7.14.tgz",
+      "integrity": "sha512-7rOiKjLkEZ0j7mPMlwrqivc+K4OSfL14slaQp06GHRiJkhiWXh2/drPe15hgNq55HmBQBpA0umKMkJcqVgmXPA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/focus": "^3.19.0",
+        "@react-aria/i18n": "^3.12.4",
+        "@react-aria/interactions": "^3.22.5",
+        "@react-aria/label": "^3.7.13",
+        "@react-aria/utils": "^3.26.0",
+        "@react-stately/slider": "^3.6.0",
+        "@react-types/shared": "^3.26.0",
+        "@react-types/slider": "^3.7.7",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/spinbutton": {
+      "version": "3.6.14",
+      "resolved": "https://registry.npmjs.org/@react-aria/spinbutton/-/spinbutton-3.6.14.tgz",
+      "integrity": "sha512-oSKe9p0Q/7W39eXRnLxlwJG5dQo4ffosRT3u2AtOcFkk2Zzj+tSQFzHQ4202nrWdzRnQ2KLTgUUNnUvXf0BJcg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/i18n": "^3.12.8",
+        "@react-aria/live-announcer": "^3.4.2",
+        "@react-aria/utils": "^3.28.2",
+        "@react-types/button": "^3.12.0",
+        "@react-types/shared": "^3.29.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/spinbutton/node_modules/@internationalized/date": {
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/@internationalized/date/-/date-3.8.0.tgz",
+      "integrity": "sha512-J51AJ0fEL68hE4CwGPa6E0PO6JDaVLd8aln48xFCSy7CZkZc96dGEGmLs2OEEbBxcsVZtfrqkXJwI2/MSG8yKw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/helpers": "^0.5.0"
+      }
+    },
+    "node_modules/@react-aria/spinbutton/node_modules/@react-aria/i18n": {
+      "version": "3.12.8",
+      "resolved": "https://registry.npmjs.org/@react-aria/i18n/-/i18n-3.12.8.tgz",
+      "integrity": "sha512-V/Nau9WuwTwxfFffQL4URyKyY2HhRlu9zmzkF2Hw/j5KmEQemD+9jfaLueG2CJu85lYL06JrZXUdnhZgKnqMkA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@internationalized/date": "^3.8.0",
+        "@internationalized/message": "^3.1.7",
+        "@internationalized/number": "^3.6.1",
+        "@internationalized/string": "^3.2.6",
+        "@react-aria/ssr": "^3.9.8",
+        "@react-aria/utils": "^3.28.2",
+        "@react-types/shared": "^3.29.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/spinbutton/node_modules/@react-aria/ssr": {
+      "version": "3.9.8",
+      "resolved": "https://registry.npmjs.org/@react-aria/ssr/-/ssr-3.9.8.tgz",
+      "integrity": "sha512-lQDE/c9uTfBSDOjaZUJS8xP2jCKVk4zjQeIlCH90xaLhHDgbpCdns3xvFpJJujfj3nI4Ll9K7A+ONUBDCASOuw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/helpers": "^0.5.0"
+      },
+      "engines": {
+        "node": ">= 12"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/spinbutton/node_modules/@react-aria/utils": {
+      "version": "3.28.2",
+      "resolved": "https://registry.npmjs.org/@react-aria/utils/-/utils-3.28.2.tgz",
+      "integrity": "sha512-J8CcLbvnQgiBn54eeEvQQbIOfBF3A1QizxMw9P4cl9MkeR03ug7RnjTIdJY/n2p7t59kLeAB3tqiczhcj+Oi5w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/ssr": "^3.9.8",
+        "@react-stately/flags": "^3.1.1",
+        "@react-stately/utils": "^3.10.6",
+        "@react-types/shared": "^3.29.0",
+        "@swc/helpers": "^0.5.0",
+        "clsx": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/spinbutton/node_modules/@react-stately/utils": {
+      "version": "3.10.6",
+      "resolved": "https://registry.npmjs.org/@react-stately/utils/-/utils-3.10.6.tgz",
+      "integrity": "sha512-O76ip4InfTTzAJrg8OaZxKU4vvjMDOpfA/PGNOytiXwBbkct2ZeZwaimJ8Bt9W1bj5VsZ81/o/tW4BacbdDOMA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/spinbutton/node_modules/@react-types/button": {
+      "version": "3.12.0",
+      "resolved": "https://registry.npmjs.org/@react-types/button/-/button-3.12.0.tgz",
+      "integrity": "sha512-YrASNa+RqGQpzJcxNAahzNuTYVID1OE6HCorrEOXIyGS3EGogHsQmFs9OyThXnGHq6q4rLlA806/jWbP9uZdxA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/shared": "^3.29.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/spinbutton/node_modules/@react-types/shared": {
+      "version": "3.29.0",
+      "resolved": "https://registry.npmjs.org/@react-types/shared/-/shared-3.29.0.tgz",
+      "integrity": "sha512-IDQYu/AHgZimObzCFdNl1LpZvQW/xcfLt3v20sorl5qRucDVj4S9os98sVTZ4IRIBjmS+MkjqpR5E70xan7ooA==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/spinbutton/node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@react-aria/ssr": {
+      "version": "3.9.7",
+      "resolved": "https://registry.npmjs.org/@react-aria/ssr/-/ssr-3.9.7.tgz",
+      "integrity": "sha512-GQygZaGlmYjmYM+tiNBA5C6acmiDWF52Nqd40bBp0Znk4M4hP+LTmI0lpI1BuKMw45T8RIhrAsICIfKwZvi2Gg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/helpers": "^0.5.0"
+      },
+      "engines": {
+        "node": ">= 12"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/switch": {
+      "version": "3.6.10",
+      "resolved": "https://registry.npmjs.org/@react-aria/switch/-/switch-3.6.10.tgz",
+      "integrity": "sha512-FtaI9WaEP1tAmra1sYlAkYXg9x75P5UtgY8pSbe9+1WRyWbuE1QZT+RNCTi3IU4fZ7iJQmXH6+VaMyzPlSUagw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/toggle": "^3.10.10",
+        "@react-stately/toggle": "^3.8.0",
+        "@react-types/shared": "^3.26.0",
+        "@react-types/switch": "^3.5.7",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/table": {
+      "version": "3.16.0",
+      "resolved": "https://registry.npmjs.org/@react-aria/table/-/table-3.16.0.tgz",
+      "integrity": "sha512-9xF9S3CJ7XRiiK92hsIKxPedD0kgcQWwqTMtj3IBynpQ4vsnRiW3YNIzrn9C3apjknRZDTSta8O2QPYCUMmw2A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/focus": "^3.19.0",
+        "@react-aria/grid": "^3.11.0",
+        "@react-aria/i18n": "^3.12.4",
+        "@react-aria/interactions": "^3.22.5",
+        "@react-aria/live-announcer": "^3.4.1",
+        "@react-aria/utils": "^3.26.0",
+        "@react-aria/visually-hidden": "^3.8.18",
+        "@react-stately/collections": "^3.12.0",
+        "@react-stately/flags": "^3.0.5",
+        "@react-stately/table": "^3.13.0",
+        "@react-types/checkbox": "^3.9.0",
+        "@react-types/grid": "^3.2.10",
+        "@react-types/shared": "^3.26.0",
+        "@react-types/table": "^3.10.3",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/tabs": {
+      "version": "3.9.8",
+      "resolved": "https://registry.npmjs.org/@react-aria/tabs/-/tabs-3.9.8.tgz",
+      "integrity": "sha512-Nur/qRFBe+Zrt4xcCJV/ULXCS3Mlae+B89bp1Gl20vSDqk6uaPtGk+cS5k03eugOvas7AQapqNJsJgKd66TChw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/focus": "^3.19.0",
+        "@react-aria/i18n": "^3.12.4",
+        "@react-aria/selection": "^3.21.0",
+        "@react-aria/utils": "^3.26.0",
+        "@react-stately/tabs": "^3.7.0",
+        "@react-types/shared": "^3.26.0",
+        "@react-types/tabs": "^3.3.11",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/textfield": {
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/@react-aria/textfield/-/textfield-3.15.0.tgz",
+      "integrity": "sha512-V5mg7y1OR6WXYHdhhm4FC7QyGc9TideVRDFij1SdOJrIo5IFB7lvwpOS0GmgwkVbtr71PTRMjZnNbrJUFU6VNA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/focus": "^3.19.0",
+        "@react-aria/form": "^3.0.11",
+        "@react-aria/label": "^3.7.13",
+        "@react-aria/utils": "^3.26.0",
+        "@react-stately/form": "^3.1.0",
+        "@react-stately/utils": "^3.10.5",
+        "@react-types/shared": "^3.26.0",
+        "@react-types/textfield": "^3.10.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/toggle": {
+      "version": "3.11.2",
+      "resolved": "https://registry.npmjs.org/@react-aria/toggle/-/toggle-3.11.2.tgz",
+      "integrity": "sha512-JOg8yYYCjLDnEpuggPo9GyXFaT/B238d3R8i/xQ6KLelpi3fXdJuZlFD6n9NQp3DJbE8Wj+wM5/VFFAi3cISpw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/interactions": "^3.25.0",
+        "@react-aria/utils": "^3.28.2",
+        "@react-stately/toggle": "^3.8.3",
+        "@react-types/checkbox": "^3.9.3",
+        "@react-types/shared": "^3.29.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/toggle/node_modules/@react-aria/interactions": {
+      "version": "3.25.0",
+      "resolved": "https://registry.npmjs.org/@react-aria/interactions/-/interactions-3.25.0.tgz",
+      "integrity": "sha512-GgIsDLlO8rDU/nFn6DfsbP9rfnzhm8QFjZkB9K9+r+MTSCn7bMntiWQgMM+5O6BiA8d7C7x4zuN4bZtc0RBdXQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/ssr": "^3.9.8",
+        "@react-aria/utils": "^3.28.2",
+        "@react-stately/flags": "^3.1.1",
+        "@react-types/shared": "^3.29.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/toggle/node_modules/@react-aria/ssr": {
+      "version": "3.9.8",
+      "resolved": "https://registry.npmjs.org/@react-aria/ssr/-/ssr-3.9.8.tgz",
+      "integrity": "sha512-lQDE/c9uTfBSDOjaZUJS8xP2jCKVk4zjQeIlCH90xaLhHDgbpCdns3xvFpJJujfj3nI4Ll9K7A+ONUBDCASOuw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/helpers": "^0.5.0"
+      },
+      "engines": {
+        "node": ">= 12"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/toggle/node_modules/@react-aria/utils": {
+      "version": "3.28.2",
+      "resolved": "https://registry.npmjs.org/@react-aria/utils/-/utils-3.28.2.tgz",
+      "integrity": "sha512-J8CcLbvnQgiBn54eeEvQQbIOfBF3A1QizxMw9P4cl9MkeR03ug7RnjTIdJY/n2p7t59kLeAB3tqiczhcj+Oi5w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/ssr": "^3.9.8",
+        "@react-stately/flags": "^3.1.1",
+        "@react-stately/utils": "^3.10.6",
+        "@react-types/shared": "^3.29.0",
+        "@swc/helpers": "^0.5.0",
+        "clsx": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/toggle/node_modules/@react-stately/toggle": {
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/@react-stately/toggle/-/toggle-3.8.3.tgz",
+      "integrity": "sha512-4T2V3P1RK4zEFz4vJjUXUXyB0g4Slm6stE6Ry20fzDWjltuW42cD2lmrd7ccTO/CXFmHLECcXQLD4GEbOj0epA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-stately/utils": "^3.10.6",
+        "@react-types/checkbox": "^3.9.3",
+        "@react-types/shared": "^3.29.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/toggle/node_modules/@react-stately/utils": {
+      "version": "3.10.6",
+      "resolved": "https://registry.npmjs.org/@react-stately/utils/-/utils-3.10.6.tgz",
+      "integrity": "sha512-O76ip4InfTTzAJrg8OaZxKU4vvjMDOpfA/PGNOytiXwBbkct2ZeZwaimJ8Bt9W1bj5VsZ81/o/tW4BacbdDOMA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/toggle/node_modules/@react-types/checkbox": {
+      "version": "3.9.3",
+      "resolved": "https://registry.npmjs.org/@react-types/checkbox/-/checkbox-3.9.3.tgz",
+      "integrity": "sha512-h6wmK7CraKHKE6L13Ut+CtnjRktbMRhkCSorv7eg82M6p4PDhZ7mfDSh13IlGR4sryT8Ka+aOjOU+EvMrKiduA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/shared": "^3.29.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/toggle/node_modules/@react-types/shared": {
+      "version": "3.29.0",
+      "resolved": "https://registry.npmjs.org/@react-types/shared/-/shared-3.29.0.tgz",
+      "integrity": "sha512-IDQYu/AHgZimObzCFdNl1LpZvQW/xcfLt3v20sorl5qRucDVj4S9os98sVTZ4IRIBjmS+MkjqpR5E70xan7ooA==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/toggle/node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@react-aria/toolbar": {
+      "version": "3.0.0-beta.11",
+      "resolved": "https://registry.npmjs.org/@react-aria/toolbar/-/toolbar-3.0.0-beta.11.tgz",
+      "integrity": "sha512-LM3jTRFNDgoEpoL568WaiuqiVM7eynSQLJis1hV0vlVnhTd7M7kzt7zoOjzxVb5Uapz02uCp1Fsm4wQMz09qwQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/focus": "^3.19.0",
+        "@react-aria/i18n": "^3.12.4",
+        "@react-aria/utils": "^3.26.0",
+        "@react-types/shared": "^3.26.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/tooltip": {
+      "version": "3.7.10",
+      "resolved": "https://registry.npmjs.org/@react-aria/tooltip/-/tooltip-3.7.10.tgz",
+      "integrity": "sha512-Udi3XOnrF/SYIz72jw9bgB74MG/yCOzF5pozHj2FH2HiJlchYv/b6rHByV/77IZemdlkmL/uugrv/7raPLSlnw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/focus": "^3.19.0",
+        "@react-aria/interactions": "^3.22.5",
+        "@react-aria/utils": "^3.26.0",
+        "@react-stately/tooltip": "^3.5.0",
+        "@react-types/shared": "^3.26.0",
+        "@react-types/tooltip": "^3.4.13",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/utils": {
+      "version": "3.26.0",
+      "resolved": "https://registry.npmjs.org/@react-aria/utils/-/utils-3.26.0.tgz",
+      "integrity": "sha512-LkZouGSjjQ0rEqo4XJosS4L3YC/zzQkfRM3KoqK6fUOmUJ9t0jQ09WjiF+uOoG9u+p30AVg3TrZRUWmoTS+koQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/ssr": "^3.9.7",
+        "@react-stately/utils": "^3.10.5",
+        "@react-types/shared": "^3.26.0",
+        "@swc/helpers": "^0.5.0",
+        "clsx": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-aria/utils/node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@react-aria/visually-hidden": {
+      "version": "3.8.18",
+      "resolved": "https://registry.npmjs.org/@react-aria/visually-hidden/-/visually-hidden-3.8.18.tgz",
+      "integrity": "sha512-l/0igp+uub/salP35SsNWq5mGmg3G5F5QMS1gDZ8p28n7CgjvzyiGhJbbca7Oxvaw1HRFzVl9ev+89I7moNnFQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/interactions": "^3.22.5",
+        "@react-aria/utils": "^3.26.0",
+        "@react-types/shared": "^3.26.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/calendar": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@react-stately/calendar/-/calendar-3.6.0.tgz",
+      "integrity": "sha512-GqUtOtGnwWjtNrJud8nY/ywI4VBP5byToNVRTnxbMl+gYO1Qe/uc5NG7zjwMxhb2kqSBHZFdkF0DXVqG2Ul+BA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@internationalized/date": "^3.6.0",
+        "@react-stately/utils": "^3.10.5",
+        "@react-types/calendar": "^3.5.0",
+        "@react-types/shared": "^3.26.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/checkbox": {
+      "version": "3.6.10",
+      "resolved": "https://registry.npmjs.org/@react-stately/checkbox/-/checkbox-3.6.10.tgz",
+      "integrity": "sha512-LHm7i4YI8A/RdgWAuADrnSAYIaYYpQeZqsp1a03Og0pJHAlZL0ymN3y2IFwbZueY0rnfM+yF+kWNXjJqbKrFEQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-stately/form": "^3.1.0",
+        "@react-stately/utils": "^3.10.5",
+        "@react-types/checkbox": "^3.9.0",
+        "@react-types/shared": "^3.26.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/collections": {
+      "version": "3.12.0",
+      "resolved": "https://registry.npmjs.org/@react-stately/collections/-/collections-3.12.0.tgz",
+      "integrity": "sha512-MfR9hwCxe5oXv4qrLUnjidwM50U35EFmInUeFf8i9mskYwWlRYS0O1/9PZ0oF1M0cKambaRHKEy98jczgb9ycA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/shared": "^3.26.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/combobox": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/@react-stately/combobox/-/combobox-3.10.1.tgz",
+      "integrity": "sha512-Rso+H+ZEDGFAhpKWbnRxRR/r7YNmYVtt+Rn0eNDNIUp3bYaxIBCdCySyAtALs4I8RZXZQ9zoUznP7YeVwG3cLg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-stately/collections": "^3.12.0",
+        "@react-stately/form": "^3.1.0",
+        "@react-stately/list": "^3.11.1",
+        "@react-stately/overlays": "^3.6.12",
+        "@react-stately/select": "^3.6.9",
+        "@react-stately/utils": "^3.10.5",
+        "@react-types/combobox": "^3.13.1",
+        "@react-types/shared": "^3.26.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/datepicker": {
+      "version": "3.11.0",
+      "resolved": "https://registry.npmjs.org/@react-stately/datepicker/-/datepicker-3.11.0.tgz",
+      "integrity": "sha512-d9MJF34A0VrhL5y5S8mAISA8uwfNCQKmR2k4KoQJm3De1J8SQeNzSjLviAwh1faDow6FXGlA6tVbTrHyDcBgBg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@internationalized/date": "^3.6.0",
+        "@internationalized/string": "^3.2.5",
+        "@react-stately/form": "^3.1.0",
+        "@react-stately/overlays": "^3.6.12",
+        "@react-stately/utils": "^3.10.5",
+        "@react-types/datepicker": "^3.9.0",
+        "@react-types/shared": "^3.26.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/flags": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@react-stately/flags/-/flags-3.1.1.tgz",
+      "integrity": "sha512-XPR5gi5LfrPdhxZzdIlJDz/B5cBf63l4q6/AzNqVWFKgd0QqY5LvWJftXkklaIUpKSJkIKQb8dphuZXDtkWNqg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/helpers": "^0.5.0"
+      }
+    },
+    "node_modules/@react-stately/form": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@react-stately/form/-/form-3.1.0.tgz",
+      "integrity": "sha512-E2wxNQ0QaTyDHD0nJFtTSnEH9A3bpJurwxhS4vgcUmESHgjFEMLlC9irUSZKgvOgb42GAq+fHoWBsgKeTp9Big==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/shared": "^3.26.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/grid": {
+      "version": "3.11.1",
+      "resolved": "https://registry.npmjs.org/@react-stately/grid/-/grid-3.11.1.tgz",
+      "integrity": "sha512-xMk2YsaIKkF8dInRLUFpUXBIqnYt88hehhq2nb65RFgsFFhngE/OkaFudSUzaYPc1KvHpW+oHqvseC+G1iDG2w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-stately/collections": "^3.12.3",
+        "@react-stately/selection": "^3.20.1",
+        "@react-types/grid": "^3.3.1",
+        "@react-types/shared": "^3.29.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/grid/node_modules/@react-stately/collections": {
+      "version": "3.12.3",
+      "resolved": "https://registry.npmjs.org/@react-stately/collections/-/collections-3.12.3.tgz",
+      "integrity": "sha512-QfSBME2QWDjUw/RmmUjrYl/j1iCYcYCIDsgZda1OeRtt63R11k0aqmmwrDRwCsA+Sv+D5QgkOp4KK+CokTzoVQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/shared": "^3.29.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/grid/node_modules/@react-types/grid": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/@react-types/grid/-/grid-3.3.1.tgz",
+      "integrity": "sha512-bPDckheJiHSIzSeSkLqrO6rXRLWvciFJr9rpCjq/+wBj6HsLh2iMpkB/SqmRHTGpPlJvlu0b7AlxK1FYE0QSKA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/shared": "^3.29.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/grid/node_modules/@react-types/shared": {
+      "version": "3.29.0",
+      "resolved": "https://registry.npmjs.org/@react-types/shared/-/shared-3.29.0.tgz",
+      "integrity": "sha512-IDQYu/AHgZimObzCFdNl1LpZvQW/xcfLt3v20sorl5qRucDVj4S9os98sVTZ4IRIBjmS+MkjqpR5E70xan7ooA==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/list": {
+      "version": "3.11.1",
+      "resolved": "https://registry.npmjs.org/@react-stately/list/-/list-3.11.1.tgz",
+      "integrity": "sha512-UCOpIvqBOjwLtk7zVTYWuKU1m1Oe61Q5lNar/GwHaV1nAiSQ8/yYlhr40NkBEs9X3plEfsV28UIpzOrYnu1tPg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-stately/collections": "^3.12.0",
+        "@react-stately/selection": "^3.18.0",
+        "@react-stately/utils": "^3.10.5",
+        "@react-types/shared": "^3.26.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/menu": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/@react-stately/menu/-/menu-3.9.0.tgz",
+      "integrity": "sha512-++sm0fzZeUs9GvtRbj5RwrP+KL9KPANp9f4SvtI3s+MP+Y/X3X7LNNePeeccGeyikB5fzMsuyvd82bRRW9IhDQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-stately/overlays": "^3.6.12",
+        "@react-types/menu": "^3.9.13",
+        "@react-types/shared": "^3.26.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/overlays": {
+      "version": "3.6.12",
+      "resolved": "https://registry.npmjs.org/@react-stately/overlays/-/overlays-3.6.12.tgz",
+      "integrity": "sha512-QinvZhwZgj8obUyPIcyURSCjTZlqZYRRCS60TF8jH8ZpT0tEAuDb3wvhhSXuYA3Xo9EHLwvLjEf3tQKKdAQArw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-stately/utils": "^3.10.5",
+        "@react-types/overlays": "^3.8.11",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/radio": {
+      "version": "3.10.9",
+      "resolved": "https://registry.npmjs.org/@react-stately/radio/-/radio-3.10.9.tgz",
+      "integrity": "sha512-kUQ7VdqFke8SDRCatw2jW3rgzMWbvw+n2imN2THETynI47NmNLzNP11dlGO2OllRtTrsLhmBNlYHa3W62pFpAw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-stately/form": "^3.1.0",
+        "@react-stately/utils": "^3.10.5",
+        "@react-types/radio": "^3.8.5",
+        "@react-types/shared": "^3.26.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/select": {
+      "version": "3.6.12",
+      "resolved": "https://registry.npmjs.org/@react-stately/select/-/select-3.6.12.tgz",
+      "integrity": "sha512-5o/NAaENO/Gxs1yui5BHLItxLnDPSQJ5HDKycuD0/gGC17BboAGEY/F9masiQ5qwRPe3JEc0QfvMRq3yZVNXog==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-stately/form": "^3.1.3",
+        "@react-stately/list": "^3.12.1",
+        "@react-stately/overlays": "^3.6.15",
+        "@react-types/select": "^3.9.11",
+        "@react-types/shared": "^3.29.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/select/node_modules/@react-stately/collections": {
+      "version": "3.12.3",
+      "resolved": "https://registry.npmjs.org/@react-stately/collections/-/collections-3.12.3.tgz",
+      "integrity": "sha512-QfSBME2QWDjUw/RmmUjrYl/j1iCYcYCIDsgZda1OeRtt63R11k0aqmmwrDRwCsA+Sv+D5QgkOp4KK+CokTzoVQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/shared": "^3.29.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/select/node_modules/@react-stately/form": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@react-stately/form/-/form-3.1.3.tgz",
+      "integrity": "sha512-Jisgm0facSS3sAzHfSgshoCo3LxfO0wmQj98MOBCGXyVL+MSwx2ilb38eXIyBCzHJzJnPRTLaK/E4T49aph47A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/shared": "^3.29.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/select/node_modules/@react-stately/list": {
+      "version": "3.12.1",
+      "resolved": "https://registry.npmjs.org/@react-stately/list/-/list-3.12.1.tgz",
+      "integrity": "sha512-N+YCInNZ2OpY0WUNvJWUTyFHtzE5yBtZ9DI4EHJDvm61+jmZ2s3HszOfa7j+7VOKq78VW3m5laqsQNWvMrLFrQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-stately/collections": "^3.12.3",
+        "@react-stately/selection": "^3.20.1",
+        "@react-stately/utils": "^3.10.6",
+        "@react-types/shared": "^3.29.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/select/node_modules/@react-stately/overlays": {
+      "version": "3.6.15",
+      "resolved": "https://registry.npmjs.org/@react-stately/overlays/-/overlays-3.6.15.tgz",
+      "integrity": "sha512-LBaGpXuI+SSd5HSGzyGJA0Gy09V2tl2G/r0lllTYqwt0RDZR6p7IrhdGVXZm6vI0oWEnih7yLC32krkVQrffgQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-stately/utils": "^3.10.6",
+        "@react-types/overlays": "^3.8.14",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/select/node_modules/@react-stately/utils": {
+      "version": "3.10.6",
+      "resolved": "https://registry.npmjs.org/@react-stately/utils/-/utils-3.10.6.tgz",
+      "integrity": "sha512-O76ip4InfTTzAJrg8OaZxKU4vvjMDOpfA/PGNOytiXwBbkct2ZeZwaimJ8Bt9W1bj5VsZ81/o/tW4BacbdDOMA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/select/node_modules/@react-types/overlays": {
+      "version": "3.8.14",
+      "resolved": "https://registry.npmjs.org/@react-types/overlays/-/overlays-3.8.14.tgz",
+      "integrity": "sha512-XJS67KHYhdMvPNHXNGdmc85gE+29QT5TwC58V4kxxHVtQh9fYzEEPzIV8K84XWSz04rRGe3fjDgRNbcqBektWQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/shared": "^3.29.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/select/node_modules/@react-types/select": {
+      "version": "3.9.11",
+      "resolved": "https://registry.npmjs.org/@react-types/select/-/select-3.9.11.tgz",
+      "integrity": "sha512-uEpQCgDlrq/5fW05FgNEsqsqpvZVKfHQO9Mp7OTqGtm4UBNAbcQ6hOV7MJwQCS25Lu2luzOYdgqDUN8eAATJVQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/shared": "^3.29.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/select/node_modules/@react-types/shared": {
+      "version": "3.29.0",
+      "resolved": "https://registry.npmjs.org/@react-types/shared/-/shared-3.29.0.tgz",
+      "integrity": "sha512-IDQYu/AHgZimObzCFdNl1LpZvQW/xcfLt3v20sorl5qRucDVj4S9os98sVTZ4IRIBjmS+MkjqpR5E70xan7ooA==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/selection": {
+      "version": "3.20.1",
+      "resolved": "https://registry.npmjs.org/@react-stately/selection/-/selection-3.20.1.tgz",
+      "integrity": "sha512-K9MP6Rfg2yvFoY2Cr+ykA7bP4EBXlGaq5Dqfa1krvcXlEgMbQka5muLHdNXqjzGgcwPmS1dx1NECD15q63NtOw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-stately/collections": "^3.12.3",
+        "@react-stately/utils": "^3.10.6",
+        "@react-types/shared": "^3.29.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/selection/node_modules/@react-stately/collections": {
+      "version": "3.12.3",
+      "resolved": "https://registry.npmjs.org/@react-stately/collections/-/collections-3.12.3.tgz",
+      "integrity": "sha512-QfSBME2QWDjUw/RmmUjrYl/j1iCYcYCIDsgZda1OeRtt63R11k0aqmmwrDRwCsA+Sv+D5QgkOp4KK+CokTzoVQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/shared": "^3.29.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/selection/node_modules/@react-stately/utils": {
+      "version": "3.10.6",
+      "resolved": "https://registry.npmjs.org/@react-stately/utils/-/utils-3.10.6.tgz",
+      "integrity": "sha512-O76ip4InfTTzAJrg8OaZxKU4vvjMDOpfA/PGNOytiXwBbkct2ZeZwaimJ8Bt9W1bj5VsZ81/o/tW4BacbdDOMA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/selection/node_modules/@react-types/shared": {
+      "version": "3.29.0",
+      "resolved": "https://registry.npmjs.org/@react-types/shared/-/shared-3.29.0.tgz",
+      "integrity": "sha512-IDQYu/AHgZimObzCFdNl1LpZvQW/xcfLt3v20sorl5qRucDVj4S9os98sVTZ4IRIBjmS+MkjqpR5E70xan7ooA==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/slider": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@react-stately/slider/-/slider-3.6.0.tgz",
+      "integrity": "sha512-w5vJxVh267pmD1X+Ppd9S3ZzV1hcg0cV8q5P4Egr160b9WMcWlUspZPtsthwUlN7qQe/C8y5IAhtde4s29eNag==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-stately/utils": "^3.10.5",
+        "@react-types/shared": "^3.26.0",
+        "@react-types/slider": "^3.7.7",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/table": {
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/@react-stately/table/-/table-3.13.0.tgz",
+      "integrity": "sha512-mRbNYrwQIE7xzVs09Lk3kPteEVFVyOc20vA8ph6EP54PiUf/RllJpxZe/WUYLf4eom9lUkRYej5sffuUBpxjCA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-stately/collections": "^3.12.0",
+        "@react-stately/flags": "^3.0.5",
+        "@react-stately/grid": "^3.10.0",
+        "@react-stately/selection": "^3.18.0",
+        "@react-stately/utils": "^3.10.5",
+        "@react-types/grid": "^3.2.10",
+        "@react-types/shared": "^3.26.0",
+        "@react-types/table": "^3.10.3",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/tabs": {
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/@react-stately/tabs/-/tabs-3.7.0.tgz",
+      "integrity": "sha512-ox4hTkfZCoR4Oyr3Op3rBlWNq2Wxie04vhEYpTZQ2hobR3l4fYaOkd7CPClILktJ3TC104j8wcb0knWxIBRx9w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-stately/list": "^3.11.1",
+        "@react-types/shared": "^3.26.0",
+        "@react-types/tabs": "^3.3.11",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/toggle": {
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/@react-stately/toggle/-/toggle-3.8.0.tgz",
+      "integrity": "sha512-pyt/k/J8BwE/2g6LL6Z6sMSWRx9HEJB83Sm/MtovXnI66sxJ2EfQ1OaXB7Su5PEL9OMdoQF6Mb+N1RcW3zAoPw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-stately/utils": "^3.10.5",
+        "@react-types/checkbox": "^3.9.0",
+        "@react-types/shared": "^3.26.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/tooltip": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/@react-stately/tooltip/-/tooltip-3.5.0.tgz",
+      "integrity": "sha512-+xzPNztJDd2XJD0X3DgWKlrgOhMqZpSzsIssXeJgO7uCnP8/Z513ESaipJhJCFC8fxj5caO/DK4Uu8hEtlB8cQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-stately/overlays": "^3.6.12",
+        "@react-types/tooltip": "^3.4.13",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/tree": {
+      "version": "3.8.6",
+      "resolved": "https://registry.npmjs.org/@react-stately/tree/-/tree-3.8.6.tgz",
+      "integrity": "sha512-lblUaxf1uAuIz5jm6PYtcJ+rXNNVkqyFWTIMx6g6gW/mYvm8GNx1G/0MLZE7E6CuDGaO9dkLSY2bB1uqyKHidA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-stately/collections": "^3.12.0",
+        "@react-stately/selection": "^3.18.0",
+        "@react-stately/utils": "^3.10.5",
+        "@react-types/shared": "^3.26.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/utils": {
+      "version": "3.10.5",
+      "resolved": "https://registry.npmjs.org/@react-stately/utils/-/utils-3.10.5.tgz",
+      "integrity": "sha512-iMQSGcpaecghDIh3mZEpZfoFH3ExBwTtuBEcvZ2XnGzCgQjeYXcMdIUwAfVQLXFTdHUHGF6Gu6/dFrYsCzySBQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-stately/virtualizer": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@react-stately/virtualizer/-/virtualizer-4.2.0.tgz",
+      "integrity": "sha512-aTMpa9AQoz/xLqn8AI1BR/caUUY7/OUo9GbuF434w2u5eGCL7+SAn3Fmq7WSCwqYyDsO+jEIERek4JTX7pEW0A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-aria/utils": "^3.26.0",
+        "@react-types/shared": "^3.26.0",
+        "@swc/helpers": "^0.5.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/accordion": {
+      "version": "3.0.0-alpha.25",
+      "resolved": "https://registry.npmjs.org/@react-types/accordion/-/accordion-3.0.0-alpha.25.tgz",
+      "integrity": "sha512-nPTRrMA5jS4QcwQ0H8J9Tzzw7+yq+KbwsPNA1ukVIfOGIB45by/1ke/eiZAXGqXxkElxi2fQuaXuWm79BWZ8zg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/shared": "^3.26.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/breadcrumbs": {
+      "version": "3.7.9",
+      "resolved": "https://registry.npmjs.org/@react-types/breadcrumbs/-/breadcrumbs-3.7.9.tgz",
+      "integrity": "sha512-eARYJo8J+VfNV8vP4uw3L2Qliba9wLV2bx9YQCYf5Lc/OE5B/y4gaTLz+Y2P3Rtn6gBPLXY447zCs5i7gf+ICg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/link": "^3.5.9",
+        "@react-types/shared": "^3.26.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/button": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/@react-types/button/-/button-3.10.1.tgz",
+      "integrity": "sha512-XTtap8o04+4QjPNAshFWOOAusUTxQlBjU2ai0BTVLShQEjHhRVDBIWsI2B2FKJ4KXT6AZ25llaxhNrreWGonmA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/shared": "^3.26.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/calendar": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/@react-types/calendar/-/calendar-3.5.0.tgz",
+      "integrity": "sha512-O3IRE7AGwAWYnvJIJ80cOy7WwoJ0m8GtX/qSmvXQAjC4qx00n+b5aFNBYAQtcyc3RM5QpW6obs9BfwGetFiI8w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@internationalized/date": "^3.6.0",
+        "@react-types/shared": "^3.26.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/checkbox": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/@react-types/checkbox/-/checkbox-3.9.0.tgz",
+      "integrity": "sha512-9hbHx0Oo2Hp5a8nV8Q75LQR0DHtvOIJbFaeqESSopqmV9EZoYjtY/h0NS7cZetgahQgnqYWQi44XGooMDCsmxA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/shared": "^3.26.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/combobox": {
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/@react-types/combobox/-/combobox-3.13.1.tgz",
+      "integrity": "sha512-7xr+HknfhReN4QPqKff5tbKTe2kGZvH+DGzPYskAtb51FAAiZsKo+WvnNAvLwg3kRoC9Rkn4TAiVBp/HgymRDw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/shared": "^3.26.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/datepicker": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/@react-types/datepicker/-/datepicker-3.9.0.tgz",
+      "integrity": "sha512-dbKL5Qsm2MQwOTtVQdOcKrrphcXAqDD80WLlSQrBLg+waDuuQ7H+TrvOT0thLKloNBlFUGnZZfXGRHINpih/0g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@internationalized/date": "^3.6.0",
+        "@react-types/calendar": "^3.5.0",
+        "@react-types/overlays": "^3.8.11",
+        "@react-types/shared": "^3.26.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/dialog": {
+      "version": "3.5.17",
+      "resolved": "https://registry.npmjs.org/@react-types/dialog/-/dialog-3.5.17.tgz",
+      "integrity": "sha512-rKe2WrT272xuCH13euegBGjJAORYXJpHsX2hlu/f02TmMG4nSLss9vKBnY2N7k7nci65k5wDTW6lcsvQ4Co5zQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/overlays": "^3.8.14",
+        "@react-types/shared": "^3.29.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/dialog/node_modules/@react-types/overlays": {
+      "version": "3.8.14",
+      "resolved": "https://registry.npmjs.org/@react-types/overlays/-/overlays-3.8.14.tgz",
+      "integrity": "sha512-XJS67KHYhdMvPNHXNGdmc85gE+29QT5TwC58V4kxxHVtQh9fYzEEPzIV8K84XWSz04rRGe3fjDgRNbcqBektWQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/shared": "^3.29.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/dialog/node_modules/@react-types/shared": {
+      "version": "3.29.0",
+      "resolved": "https://registry.npmjs.org/@react-types/shared/-/shared-3.29.0.tgz",
+      "integrity": "sha512-IDQYu/AHgZimObzCFdNl1LpZvQW/xcfLt3v20sorl5qRucDVj4S9os98sVTZ4IRIBjmS+MkjqpR5E70xan7ooA==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/form": {
+      "version": "3.7.8",
+      "resolved": "https://registry.npmjs.org/@react-types/form/-/form-3.7.8.tgz",
+      "integrity": "sha512-0wOS97/X0ijTVuIqik1lHYTZnk13QkvMTKvIEhM7c6YMU3vPiirBwLbT2kJiAdwLiymwcCkrBdDF1NTRG6kPFA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/shared": "^3.26.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/grid": {
+      "version": "3.2.10",
+      "resolved": "https://registry.npmjs.org/@react-types/grid/-/grid-3.2.10.tgz",
+      "integrity": "sha512-Z5cG0ITwqjUE4kWyU5/7VqiPl4wqMJ7kG/ZP7poAnLmwRsR8Ai0ceVn+qzp5nTA19cgURi8t3LsXn3Ar1FBoog==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/shared": "^3.26.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/link": {
+      "version": "3.5.9",
+      "resolved": "https://registry.npmjs.org/@react-types/link/-/link-3.5.9.tgz",
+      "integrity": "sha512-JcKDiDMqrq/5Vpn+BdWQEuXit4KN4HR/EgIi3yKnNbYkLzxBoeQZpQgvTaC7NEQeZnSqkyXQo3/vMUeX/ZNIKw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/shared": "^3.26.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/listbox": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@react-types/listbox/-/listbox-3.6.0.tgz",
+      "integrity": "sha512-+1ugDKTxson/WNOQZO4BfrnQ6cGDt+72mEytXMsSsd4aEC+x3RyUv6NKwdOl4n602cOreo0MHtap1X2BOACVoQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/shared": "^3.29.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/listbox/node_modules/@react-types/shared": {
+      "version": "3.29.0",
+      "resolved": "https://registry.npmjs.org/@react-types/shared/-/shared-3.29.0.tgz",
+      "integrity": "sha512-IDQYu/AHgZimObzCFdNl1LpZvQW/xcfLt3v20sorl5qRucDVj4S9os98sVTZ4IRIBjmS+MkjqpR5E70xan7ooA==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/menu": {
+      "version": "3.9.13",
+      "resolved": "https://registry.npmjs.org/@react-types/menu/-/menu-3.9.13.tgz",
+      "integrity": "sha512-7SuX6E2tDsqQ+HQdSvIda1ji/+ujmR86dtS9CUu5yWX91P25ufRjZ72EvLRqClWNQsj1Xl4+2zBDLWlceznAjw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/overlays": "^3.8.11",
+        "@react-types/shared": "^3.26.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/overlays": {
+      "version": "3.8.11",
+      "resolved": "https://registry.npmjs.org/@react-types/overlays/-/overlays-3.8.11.tgz",
+      "integrity": "sha512-aw7T0rwVI3EuyG5AOaEIk8j7dZJQ9m34XAztXJVZ/W2+4pDDkLDbJ/EAPnuo2xGYRGhowuNDn4tDju01eHYi+w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/shared": "^3.26.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/progress": {
+      "version": "3.5.8",
+      "resolved": "https://registry.npmjs.org/@react-types/progress/-/progress-3.5.8.tgz",
+      "integrity": "sha512-PR0rN5mWevfblR/zs30NdZr+82Gka/ba7UHmYOW9/lkKlWeD7PHgl1iacpd/3zl/jUF22evAQbBHmk1mS6Mpqw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/shared": "^3.26.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/radio": {
+      "version": "3.8.5",
+      "resolved": "https://registry.npmjs.org/@react-types/radio/-/radio-3.8.5.tgz",
+      "integrity": "sha512-gSImTPid6rsbJmwCkTliBIU/npYgJHOFaI3PNJo7Y0QTAnFelCtYeFtBiWrFodSArSv7ASqpLLUEj9hZu/rxIg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/shared": "^3.26.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/select": {
+      "version": "3.9.8",
+      "resolved": "https://registry.npmjs.org/@react-types/select/-/select-3.9.8.tgz",
+      "integrity": "sha512-RGsYj2oFjXpLnfcvWMBQnkcDuKkwT43xwYWZGI214/gp/B64tJiIUgTM5wFTRAeGDX23EePkhCQF+9ctnqFd6g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/shared": "^3.26.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/shared": {
+      "version": "3.26.0",
+      "resolved": "https://registry.npmjs.org/@react-types/shared/-/shared-3.26.0.tgz",
+      "integrity": "sha512-6FuPqvhmjjlpEDLTiYx29IJCbCNWPlsyO+ZUmCUXzhUv2ttShOXfw8CmeHWHftT/b2KweAWuzqSlfeXPR76jpw==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/slider": {
+      "version": "3.7.10",
+      "resolved": "https://registry.npmjs.org/@react-types/slider/-/slider-3.7.10.tgz",
+      "integrity": "sha512-Yb8wbpu2gS7AwvJUuz0IdZBRi6eIBZq32BSss4UHX0StA8dtR1/K4JeTsArxwiA3P0BA6t0gbR6wzxCvVA9fRw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/shared": "^3.29.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/slider/node_modules/@react-types/shared": {
+      "version": "3.29.0",
+      "resolved": "https://registry.npmjs.org/@react-types/shared/-/shared-3.29.0.tgz",
+      "integrity": "sha512-IDQYu/AHgZimObzCFdNl1LpZvQW/xcfLt3v20sorl5qRucDVj4S9os98sVTZ4IRIBjmS+MkjqpR5E70xan7ooA==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/switch": {
+      "version": "3.5.10",
+      "resolved": "https://registry.npmjs.org/@react-types/switch/-/switch-3.5.10.tgz",
+      "integrity": "sha512-YyNhx4CvuJ0Rvv7yMuQaqQuOIeg+NwLV00NHHJ+K0xEANSLcICLOLPNMOqRIqLSQDz5vDI705UKk8gVcxqPX5g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/shared": "^3.29.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/switch/node_modules/@react-types/shared": {
+      "version": "3.29.0",
+      "resolved": "https://registry.npmjs.org/@react-types/shared/-/shared-3.29.0.tgz",
+      "integrity": "sha512-IDQYu/AHgZimObzCFdNl1LpZvQW/xcfLt3v20sorl5qRucDVj4S9os98sVTZ4IRIBjmS+MkjqpR5E70xan7ooA==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/table": {
+      "version": "3.10.3",
+      "resolved": "https://registry.npmjs.org/@react-types/table/-/table-3.10.3.tgz",
+      "integrity": "sha512-Ac+W+m/zgRzlTU8Z2GEg26HkuJFswF9S6w26r+R3MHwr8z2duGPvv37XRtE1yf3dbpRBgHEAO141xqS2TqGwNg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/grid": "^3.2.10",
+        "@react-types/shared": "^3.26.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/tabs": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/@react-types/tabs/-/tabs-3.3.11.tgz",
+      "integrity": "sha512-BjF2TqBhZaIcC4lc82R5pDJd1F7kstj1K0Nokhz99AGYn8C0ITdp6lR+DPVY9JZRxKgP9R2EKfWGI90Lo7NQdA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/shared": "^3.26.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/textfield": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/@react-types/textfield/-/textfield-3.10.0.tgz",
+      "integrity": "sha512-ShU3d6kLJGQjPXccVFjM3KOXdj3uyhYROqH9YgSIEVxgA9W6LRflvk/IVBamD9pJYTPbwmVzuP0wQkTDupfZ1w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/shared": "^3.26.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/@react-types/tooltip": {
+      "version": "3.4.13",
+      "resolved": "https://registry.npmjs.org/@react-types/tooltip/-/tooltip-3.4.13.tgz",
+      "integrity": "sha512-KPekFC17RTT8kZlk7ZYubueZnfsGTDOpLw7itzolKOXGddTXsrJGBzSB4Bb060PBVllaDO0MOrhPap8OmrIl1Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@react-types/overlays": "^3.8.11",
+        "@react-types/shared": "^3.26.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
@@ -1545,6 +5065,33 @@
         "tailwindcss": "4.1.5"
       }
     },
+    "node_modules/@tanstack/react-virtual": {
+      "version": "3.11.2",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-virtual/-/react-virtual-3.11.2.tgz",
+      "integrity": "sha512-OuFzMXPF4+xZgx8UzJha0AieuMihhhaWG0tCqpp6tDzlFwOmNBPYMuLOtMJ1Tr4pXLHmgjcWhG6RlknY2oNTdQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/virtual-core": "3.11.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@tanstack/virtual-core": {
+      "version": "3.11.2",
+      "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.11.2.tgz",
+      "integrity": "sha512-vTtpNt7mKCiZ1pwU9hfKPhpdVO2sVzFQsxoVBGtOSHxlrRRzYr8iQ2TlwbAcRYCcEiZ9ECAM8kBzH0v2+VzfKw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
     "node_modules/@tybys/wasm-util": {
       "version": "0.9.0",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.9.0.tgz",
@@ -1608,6 +5155,21 @@
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/lodash": {
+      "version": "4.17.16",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.16.tgz",
+      "integrity": "sha512-HX7Em5NYQAXKW+1T+FiuG27NGwzJfCX3s1GjOa7ujxZa52kjJLOr4FUxT+giF6Tgxv1e+/czV/iTtBw27WTU9g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/lodash.debounce": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/lodash.debounce/-/lodash.debounce-4.0.9.tgz",
+      "integrity": "sha512-Ma5JcgTREwpLRwMM+XwBR7DaWe96nC38uCBDFKZWbNKD+osjVzdpnUSwBcqCptrp16sSOLBAUb50Car5I0TCsQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/lodash": "*"
+      }
     },
     "node_modules/@types/mdast": {
       "version": "4.0.4",
@@ -2700,12 +6262,20 @@
       "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==",
       "license": "MIT"
     },
+    "node_modules/clsx": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.2.1.tgz",
+      "integrity": "sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/color": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/color/-/color-4.2.3.tgz",
       "integrity": "sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "color-convert": "^2.0.1",
         "color-string": "^1.9.0"
@@ -2718,7 +6288,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -2731,7 +6300,6 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/color-string": {
@@ -2739,11 +6307,16 @@
       "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.1.tgz",
       "integrity": "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "color-name": "^1.0.0",
         "simple-swizzle": "^0.2.2"
       }
+    },
+    "node_modules/color2k": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/color2k/-/color2k-2.0.3.tgz",
+      "integrity": "sha512-zW190nQTIoXcGCaU08DvVNFTmQhUpnJfVuAKfWqUQkflXKpaDdpaYoM0iluLS9lgJNHyBF58KKA2FBEwkD7wog==",
+      "license": "MIT"
     },
     "node_modules/comma-separated-tokens": {
       "version": "2.0.3",
@@ -2754,6 +6327,12 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
+    },
+    "node_modules/compute-scroll-into-view": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/compute-scroll-into-view/-/compute-scroll-into-view-3.1.1.tgz",
+      "integrity": "sha512-VRhuHOLoKYOy4UbilLbUzbYg93XLjv2PncJC50EuTWPA3gaja1UjBsUP/D/9/juV3vQFr6XBEzn9KCAHdUvOHw==",
+      "license": "MIT"
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
@@ -2917,6 +6496,12 @@
         }
       }
     },
+    "node_modules/decimal.js": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.5.0.tgz",
+      "integrity": "sha512-8vDa8Qxvr/+d94hSh5P3IJwI5t8/c0KsMp+g8bNw9cY2icONa5aPfvKeieW1WlG0WQYwwhJ7mjui2xtiePQSXw==",
+      "license": "MIT"
+    },
     "node_modules/decode-named-character-reference": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.1.0.tgz",
@@ -2936,6 +6521,15 @@
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/deepmerge": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
+      "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/define-data-property": {
       "version": "1.1.4",
@@ -3949,6 +7543,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/flat": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
+      "integrity": "sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==",
+      "license": "BSD-3-Clause",
+      "bin": {
+        "flat": "cli.js"
+      }
+    },
     "node_modules/flat-cache": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
@@ -3994,6 +7597,33 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/framer-motion": {
+      "version": "12.10.4",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.10.4.tgz",
+      "integrity": "sha512-gGkavMW3QFDCxI+adVu5sn2NtIRHYPGVLDSJ0S/6B0ZoxPaql2F9foWdg9sGIP6sPA8cbNDfxYf9VlhD3+FkVQ==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-dom": "^12.10.4",
+        "motion-utils": "^12.9.4",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
       }
     },
     "node_modules/fresh": {
@@ -4411,6 +8041,16 @@
       "integrity": "sha512-0aO8FkhNZlj/ZIbNi7Lxxr12obT7cL1moPfE4tg1LkX7LlLfC6DeX4l2ZEud1ukP9jNQyNnfzQVqwbwmAATY4Q==",
       "license": "MIT"
     },
+    "node_modules/input-otp": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/input-otp/-/input-otp-1.4.1.tgz",
+      "integrity": "sha512-+yvpmKYKHi9jIGngxagY9oWiiblPB7+nEO75F2l2o4vs+6vpPZZmUl4tBNYuTCvQjhvEIbdNeJu70bhfYP2nbw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc"
+      }
+    },
     "node_modules/internal-slot": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.1.0.tgz",
@@ -4424,6 +8064,18 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/intl-messageformat": {
+      "version": "10.7.16",
+      "resolved": "https://registry.npmjs.org/intl-messageformat/-/intl-messageformat-10.7.16.tgz",
+      "integrity": "sha512-UmdmHUmp5CIKKjSoE10la5yfU+AYJAaiYLsodbjL4lji83JNvgOQUjGaGhGrpFCb0Uh7sl7qfP1IyILa8Z40ug==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@formatjs/ecma402-abstract": "2.3.4",
+        "@formatjs/fast-memoize": "2.2.7",
+        "@formatjs/icu-messageformat-parser": "2.11.2",
+        "tslib": "^2.8.0"
       }
     },
     "node_modules/ipaddr.js": {
@@ -4482,8 +8134,7 @@
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
       "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ==",
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/is-async-function": {
       "version": "2.1.1",
@@ -6054,6 +9705,21 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/motion-dom": {
+      "version": "12.10.4",
+      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.10.4.tgz",
+      "integrity": "sha512-GSv8kz0ANFfeGrFKi99s3GQjLiL1IKH3KtSNEqrPiVbloHVRiNbNtpsYQq9rkV2AV+7jxvd1X1ObUMVDnAEnXA==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-utils": "^12.9.4"
+      }
+    },
+    "node_modules/motion-utils": {
+      "version": "12.9.4",
+      "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-12.9.4.tgz",
+      "integrity": "sha512-BW3I65zeM76CMsfh3kHid9ansEJk9Qvl+K5cu4DVHKGsI52n76OJ4z2CUJUV+Mn3uEP9k1JJA3tClG0ggSrRcg==",
+      "license": "MIT"
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -6864,6 +10530,23 @@
         "react": ">=18"
       }
     },
+    "node_modules/react-textarea-autosize": {
+      "version": "8.5.9",
+      "resolved": "https://registry.npmjs.org/react-textarea-autosize/-/react-textarea-autosize-8.5.9.tgz",
+      "integrity": "sha512-U1DGlIQN5AwgjTyOEnI1oCcMuEr1pv1qOtklB2l4nyMGbHzWrI0eFsYK0zos2YWqAolJyG0IWJaqWmWj5ETh0A==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.20.13",
+        "use-composed-ref": "^1.3.0",
+        "use-latest": "^1.2.1"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.10.tgz",
@@ -7123,6 +10806,15 @@
       "integrity": "sha512-NlHwttCI/l5gCPR3D1nNXtWABUmBwvZpEQiD4IXSbIDq8BzLIK/7Ir5gTFSGZDUu37K5cMNp0hFtzO38sC7gWA==",
       "license": "MIT"
     },
+    "node_modules/scroll-into-view-if-needed": {
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/scroll-into-view-if-needed/-/scroll-into-view-if-needed-3.0.10.tgz",
+      "integrity": "sha512-t44QCeDKAPf1mtQH3fYpWz8IM/DyvHLjs8wUvvwMYxk5moOqCzrMSxK6HQVD0QVmVjXFavoFIPRVrMuJPKAvtg==",
+      "license": "MIT",
+      "dependencies": {
+        "compute-scroll-into-view": "^3.0.2"
+      }
+    },
     "node_modules/semver": {
       "version": "7.7.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
@@ -7376,7 +11068,6 @@
       "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
       "integrity": "sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "is-arrayish": "^0.3.1"
       }
@@ -7642,11 +11333,46 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/tailwind-merge": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-2.6.0.tgz",
+      "integrity": "sha512-P+Vu1qXfzediirmHOC3xKGAYeZtPcV9g76X+xg2FD4tYgR71ewMA35Y3sCz3zhiN/dwefRpJX0yBcgwi1fXNQA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/dcastil"
+      }
+    },
+    "node_modules/tailwind-variants": {
+      "version": "0.1.20",
+      "resolved": "https://registry.npmjs.org/tailwind-variants/-/tailwind-variants-0.1.20.tgz",
+      "integrity": "sha512-AMh7x313t/V+eTySKB0Dal08RHY7ggYK0MSn/ad8wKWOrDUIzyiWNayRUm2PIJ4VRkvRnfNuyRuKbLV3EN+ewQ==",
+      "license": "MIT",
+      "dependencies": {
+        "tailwind-merge": "^1.14.0"
+      },
+      "engines": {
+        "node": ">=16.x",
+        "pnpm": ">=7.x"
+      },
+      "peerDependencies": {
+        "tailwindcss": "*"
+      }
+    },
+    "node_modules/tailwind-variants/node_modules/tailwind-merge": {
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-1.14.0.tgz",
+      "integrity": "sha512-3mFKyCo/MBcgyOTlrY8T7odzZFx+w+qKSMAmdFzRvqBfLlSigU6TZnlFHK0lkMwj9Bj8OYU+9yW9lmGuS0QEnQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/dcastil"
+      }
+    },
     "node_modules/tailwindcss": {
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.5.tgz",
       "integrity": "sha512-nYtSPfWGDiWgCkwQG/m+aX83XCwf62sBgg3bIlNiiOcggnS1x3uVRDAuyelBFL+vJdOPPCGElxv9DjHJjRHiVA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/tapable": {
@@ -8084,6 +11810,51 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/use-composed-ref": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/use-composed-ref/-/use-composed-ref-1.4.0.tgz",
+      "integrity": "sha512-djviaxuOOh7wkj0paeO1Q/4wMZ8Zrnag5H6yBvzN7AKKe8beOaED9SF5/ByLqsku8NP4zQqsvM2u3ew/tJK8/w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/use-isomorphic-layout-effect": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/use-isomorphic-layout-effect/-/use-isomorphic-layout-effect-1.2.0.tgz",
+      "integrity": "sha512-q6ayo8DWoPZT0VdG4u3D3uxcgONP3Mevx2i2b0434cwWBoL+aelL1DzkXI6w3PhTZzUeR2kaVlZn70iCiseP6w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/use-latest": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/use-latest/-/use-latest-1.3.0.tgz",
+      "integrity": "sha512-mhg3xdm9NaM8q+gLT8KryJPnRFOz1/5XPBhmDEVZK1webPzDjrPk7f/mbpeLqTgB9msytYWANxgALOCJKnLvcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "use-isomorphic-layout-effect": "^1.1.1"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/uuid": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,9 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "@nextui-org/react": "^2.6.11",
     "chart.js": "^4.4.9",
+    "framer-motion": "^12.10.4",
     "next": "15.3.1",
     "next-auth": "^4.24.11",
     "octokit": "^4.1.3",

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,107 @@
+/** @type {import('tailwindcss').Config} */
+import { nextui } from '@nextui-org/react';
+
+const config = {
+  content: [
+    './app/**/*.{js,ts,jsx,tsx,mdx}',
+    './node_modules/@nextui-org/theme/dist/**/*.{js,ts,jsx,tsx}'
+  ],
+  theme: {
+    extend: {
+      fontFamily: {
+        sans: ['var(--font-geist-sans)'],
+        mono: ['var(--font-geist-mono)'],
+      },
+      colors: {
+        // Custom colors for the application
+        'github-dark': '#0d1117',
+        'github-darker': '#010409',
+        'github-light': '#f6f8fa',
+      },
+      backdropFilter: {
+        'none': 'none',
+        'blur': 'blur(20px)',
+      },
+      animation: {
+        'pulse-slow': 'pulse 3s cubic-bezier(0.4, 0, 0.6, 1) infinite',
+      },
+    },
+  },
+  darkMode: 'class',
+  plugins: [
+    nextui({
+      themes: {
+        light: {
+          colors: {
+            background: '#f6f8fa',
+            foreground: '#24292f',
+            primary: {
+              50: '#f0f9ff',
+              100: '#e0f2fe',
+              200: '#bae6fd',
+              300: '#7dd3fc',
+              400: '#38bdf8',
+              500: '#0ea5e9',
+              600: '#0284c7',
+              700: '#0369a1',
+              800: '#075985',
+              900: '#0c4a6e',
+              DEFAULT: '#0284c7',
+              foreground: '#ffffff',
+            },
+            focus: '#0284c7',
+          },
+          layout: {
+            disabledOpacity: '0.3',
+            radius: {
+              small: '4px',
+              medium: '6px',
+              large: '8px',
+            },
+            borderWidth: {
+              small: '1px',
+              medium: '2px',
+              large: '3px',
+            },
+          },
+        },
+        dark: {
+          colors: {
+            background: '#0d1117',
+            foreground: '#f6f8fa',
+            primary: {
+              50: '#f0f9ff',
+              100: '#e0f2fe',
+              200: '#bae6fd',
+              300: '#7dd3fc',
+              400: '#38bdf8',
+              500: '#0ea5e9',
+              600: '#0284c7',
+              700: '#0369a1',
+              800: '#075985',
+              900: '#0c4a6e',
+              DEFAULT: '#0ea5e9',
+              foreground: '#ffffff',
+            },
+            focus: '#0ea5e9',
+          },
+          layout: {
+            disabledOpacity: '0.3',
+            radius: {
+              small: '4px',
+              medium: '6px',
+              large: '8px',
+            },
+            borderWidth: {
+              small: '1px',
+              medium: '2px',
+              large: '3px',
+            },
+          },
+        },
+      },
+    }),
+  ],
+};
+
+export default config;


### PR DESCRIPTION
This PR adds comprehensive GitHub Projects integration to GitHub Nexus:

## Features
- View, create, and manage GitHub Projects
- Project dashboard with tabs for user, repository, and organization projects
- Project detail page with columns and cards
- Create and manage project columns
- Create and manage cards within columns
- Integration with GitHub's Projects API

## Implementation
- Added GitHub Projects methods to GitHubService
- Created components for displaying and interacting with projects
- Added dedicated projects dashboard page and project detail page
- Added navigation to the projects pages from header and sidebar
- Responsive design consistent with the rest of the application

This feature enhances GitHub Nexus by providing a dedicated interface for managing GitHub Projects, making it easier for users to organize and track their work using GitHub's project management tools.