### PR TITLE
Add GitHub Projects (beta) integration

### DIFF
--- a/app/components/projects/ProjectBetaBoard.tsx
+++ b/app/components/projects/ProjectBetaBoard.tsx
@@ -1,0 +1,477 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { useGitHub } from "../../context/GitHubContext";
+import {
+  Card,
+  CardBody,
+  CardHeader,
+  Button,
+  Spinner,
+  Chip,
+  Dropdown,
+  DropdownTrigger,
+  DropdownMenu,
+  DropdownItem,
+  Input,
+  Modal,
+  ModalContent,
+  ModalHeader,
+  ModalBody,
+  ModalFooter,
+  Textarea
+} from "@nextui-org/react";
+import { PlusIcon, PencilIcon, TrashIcon, LinkIcon } from "@heroicons/react/24/outline";
+
+interface ProjectBetaItem {
+  id: string;
+  content?: {
+    id: string;
+    title: string;
+    number: number;
+    state: string;
+    repository?: {
+      name: string;
+      owner: {
+        login: string;
+      };
+    };
+  };
+  fieldValues: {
+    nodes: Array<{
+      text?: string;
+      date?: string;
+      name?: string;
+      field: {
+        name: string;
+      };
+    }>;
+  };
+}
+
+interface ProjectBetaField {
+  id: string;
+  name: string;
+  dataType: string;
+  options?: Array<{
+    id: string;
+    name: string;
+    color: string;
+  }>;
+}
+
+interface ProjectBetaBoardProps {
+  projectId: string;
+  fields: ProjectBetaField[];
+  items: ProjectBetaItem[];
+  onItemAdded: () => void;
+  onItemUpdated: () => void;
+}
+
+export default function ProjectBetaBoard({
+  projectId,
+  fields,
+  items,
+  onItemAdded,
+  onItemUpdated
+}: ProjectBetaBoardProps) {
+  const { githubService } = useGitHub();
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [showAddItemModal, setShowAddItemModal] = useState(false);
+  const [showLinkItemModal, setShowLinkItemModal] = useState(false);
+  const [newItemTitle, setNewItemTitle] = useState("");
+  const [newItemBody, setNewItemBody] = useState("");
+  const [searchQuery, setSearchQuery] = useState("");
+  const [searchResults, setSearchResults] = useState<any[]>([]);
+  const [selectedRepo, setSelectedRepo] = useState<string>("");
+  const [repositories, setRepositories] = useState<any[]>([]);
+  const [activeTab, setActiveTab] = useState("issues");
+
+  // Get status field if it exists
+  const statusField = fields.find(field => 
+    field.name.toLowerCase() === "status" && field.dataType === "SINGLE_SELECT"
+  );
+
+  // Group items by status
+  const groupedItems: Record<string, ProjectBetaItem[]> = {};
+  
+  if (statusField && statusField.options) {
+    // Initialize groups based on status options
+    statusField.options.forEach(option => {
+      groupedItems[option.name] = [];
+    });
+    
+    // Add "No Status" group for items without a status
+    groupedItems["No Status"] = [];
+    
+    // Group items
+    items.forEach(item => {
+      const statusValue = item.fieldValues.nodes.find(
+        value => value.field.name.toLowerCase() === "status" && value.name
+      );
+      
+      if (statusValue && statusValue.name) {
+        if (groupedItems[statusValue.name]) {
+          groupedItems[statusValue.name].push(item);
+        } else {
+          groupedItems["No Status"].push(item);
+        }
+      } else {
+        groupedItems["No Status"].push(item);
+      }
+    });
+  } else {
+    // If no status field, just show all items in one group
+    groupedItems["All Items"] = items;
+  }
+
+  // Fetch repositories when component mounts
+  useEffect(() => {
+    async function fetchRepositories() {
+      if (!githubService) return;
+      
+      try {
+        setIsLoading(true);
+        const user = await githubService.getCurrentUser();
+        const repos = await githubService.getUserRepositories(user.login);
+        setRepositories(repos);
+        
+        if (repos.length > 0) {
+          setSelectedRepo(repos[0].full_name);
+        }
+      } catch (error) {
+        console.error("Error fetching repositories:", error);
+        setError("Failed to fetch repositories. Please try again.");
+      } finally {
+        setIsLoading(false);
+      }
+    }
+    
+    if (showLinkItemModal) {
+      fetchRepositories();
+    }
+  }, [githubService, showLinkItemModal]);
+
+  // Handle search for linking items
+  const handleSearch = async () => {
+    if (!githubService || !selectedRepo || !searchQuery.trim()) return;
+    
+    try {
+      setIsLoading(true);
+      setError(null);
+      
+      const [owner, repo] = selectedRepo.split("/");
+      
+      if (activeTab === "issues") {
+        const issues = await githubService.searchIssues(searchQuery, owner, repo);
+        setSearchResults(issues.filter((issue: any) => !issue.pull_request));
+      } else {
+        const pullRequests = await githubService.searchIssues(searchQuery, owner, repo);
+        setSearchResults(pullRequests.filter((issue: any) => issue.pull_request));
+      }
+    } catch (error) {
+      console.error("Error searching items:", error);
+      setError("Failed to search. Please try again.");
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  // Handle creating a draft issue
+  const handleCreateDraftIssue = async () => {
+    if (!githubService || !newItemTitle.trim()) return;
+    
+    try {
+      setIsLoading(true);
+      setError(null);
+      
+      await githubService.createDraftIssue(
+        projectId,
+        newItemTitle,
+        newItemBody
+      );
+      
+      setNewItemTitle("");
+      setNewItemBody("");
+      setShowAddItemModal(false);
+      onItemAdded();
+    } catch (error) {
+      console.error("Error creating draft issue:", error);
+      setError("Failed to create draft issue. Please try again.");
+      setIsLoading(false);
+    }
+  };
+
+  // Handle linking an item to the project
+  const handleLinkItem = async (item: any) => {
+    if (!githubService) return;
+    
+    try {
+      setIsLoading(true);
+      setError(null);
+      
+      await githubService.addItemToProject(
+        projectId,
+        item.node_id
+      );
+      
+      setShowLinkItemModal(false);
+      onItemAdded();
+    } catch (error) {
+      console.error("Error linking item:", error);
+      setError("Failed to link item. Please try again.");
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <div className="space-y-6">
+      {error && (
+        <div className="bg-red-100 dark:bg-red-900 text-red-800 dark:text-red-200 p-4 rounded-md">
+          {error}
+        </div>
+      )}
+      
+      <div className="flex justify-between items-center">
+        <h2 className="text-xl font-semibold">Project Items</h2>
+        <div className="flex space-x-2">
+          <Button 
+            color="primary" 
+            startContent={<PlusIcon className="h-4 w-4" />}
+            onPress={() => setShowAddItemModal(true)}
+          >
+            Add Item
+          </Button>
+          <Button
+            variant="flat"
+            startContent={<LinkIcon className="h-4 w-4" />}
+            onPress={() => setShowLinkItemModal(true)}
+          >
+            Link Item
+          </Button>
+        </div>
+      </div>
+      
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+        {Object.entries(groupedItems).map(([status, statusItems]) => (
+          <Card key={status} className="h-full">
+            <CardHeader className="flex justify-between items-center bg-gray-100 dark:bg-gray-800">
+              <div className="flex items-center">
+                <h3 className="text-md font-medium">{status}</h3>
+                <Chip size="sm" className="ml-2">{statusItems.length}</Chip>
+              </div>
+            </CardHeader>
+            <CardBody className="overflow-y-auto max-h-[500px]">
+              {statusItems.length > 0 ? (
+                <div className="space-y-3">
+                  {statusItems.map(item => (
+                    <Card key={item.id} shadow="sm" className="border border-gray-200 dark:border-gray-700">
+                      <CardBody className="p-3">
+                        <div className="text-sm font-medium">
+                          {item.content ? (
+                            <div>
+                              <div className="flex items-center mb-1">
+                                <span className="text-xs text-gray-500 dark:text-gray-400">
+                                  {item.content.repository?.owner.login}/{item.content.repository?.name} #{item.content.number}
+                                </span>
+                              </div>
+                              <a 
+                                href={`/repositories/${item.content.repository?.owner.login}/${item.content.repository?.name}/${item.content.state === 'open' ? 'issues' : 'pull'}/${item.content.number}`}
+                                className="hover:text-blue-600 dark:hover:text-blue-400"
+                              >
+                                {item.content.title}
+                              </a>
+                              <Chip 
+                                size="sm" 
+                                className="ml-2" 
+                                color={item.content.state === 'open' ? 'success' : 'danger'}
+                              >
+                                {item.content.state}
+                              </Chip>
+                            </div>
+                          ) : (
+                            // Draft issue
+                            <div>
+                              {item.fieldValues.nodes.find(v => v.field.name === "Title")?.text || "Untitled Draft"}
+                            </div>
+                          )}
+                        </div>
+                      </CardBody>
+                    </Card>
+                  ))}
+                </div>
+              ) : (
+                <div className="text-center py-6 text-gray-500 dark:text-gray-400">
+                  No items in this status
+                </div>
+              )}
+            </CardBody>
+          </Card>
+        ))}
+      </div>
+
+      {/* Add Item Modal */}
+      <Modal isOpen={showAddItemModal} onClose={() => setShowAddItemModal(false)}>
+        <ModalContent>
+          {(onClose) => (
+            <>
+              <ModalHeader>Add Draft Issue</ModalHeader>
+              <ModalBody>
+                <Input
+                  label="Title"
+                  placeholder="Enter issue title"
+                  value={newItemTitle}
+                  onChange={(e) => setNewItemTitle(e.target.value)}
+                  isRequired
+                />
+                <Textarea
+                  label="Description"
+                  placeholder="Enter issue description"
+                  value={newItemBody}
+                  onChange={(e) => setNewItemBody(e.target.value)}
+                  minRows={3}
+                />
+              </ModalBody>
+              <ModalFooter>
+                <Button color="danger" variant="light" onPress={onClose}>
+                  Cancel
+                </Button>
+                <Button 
+                  color="primary" 
+                  onPress={handleCreateDraftIssue}
+                  isLoading={isLoading}
+                  isDisabled={!newItemTitle.trim()}
+                >
+                  Create
+                </Button>
+              </ModalFooter>
+            </>
+          )}
+        </ModalContent>
+      </Modal>
+
+      {/* Link Item Modal */}
+      <Modal isOpen={showLinkItemModal} onClose={() => setShowLinkItemModal(false)} size="lg">
+        <ModalContent>
+          {(onClose) => (
+            <>
+              <ModalHeader>Link Issue or Pull Request</ModalHeader>
+              <ModalBody>
+                <div className="space-y-4">
+                  <div>
+                    <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                      Repository
+                    </label>
+                    <select
+                      value={selectedRepo}
+                      onChange={(e) => setSelectedRepo(e.target.value)}
+                      className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500 dark:bg-gray-800 dark:text-white"
+                      disabled={isLoading || repositories.length === 0}
+                    >
+                      {repositories.map((repo) => (
+                        <option key={repo.id} value={repo.full_name}>
+                          {repo.full_name}
+                        </option>
+                      ))}
+                    </select>
+                  </div>
+                  
+                  <div className="flex space-x-2">
+                    <Button
+                      className={activeTab === "issues" ? "bg-blue-600 text-white" : "bg-gray-200 text-gray-800 dark:bg-gray-700 dark:text-white"}
+                      onPress={() => setActiveTab("issues")}
+                    >
+                      Issues
+                    </Button>
+                    <Button
+                      className={activeTab === "pullRequests" ? "bg-blue-600 text-white" : "bg-gray-200 text-gray-800 dark:bg-gray-700 dark:text-white"}
+                      onPress={() => setActiveTab("pullRequests")}
+                    >
+                      Pull Requests
+                    </Button>
+                  </div>
+                  
+                  <div className="flex space-x-2">
+                    <Input
+                      placeholder={`Search ${activeTab === "issues" ? "issues" : "pull requests"}...`}
+                      value={searchQuery}
+                      onChange={(e) => setSearchQuery(e.target.value)}
+                      onKeyDown={(e) => e.key === "Enter" && handleSearch()}
+                      disabled={isLoading || !selectedRepo}
+                      className="flex-1"
+                    />
+                    <Button
+                      color="primary"
+                      onClick={handleSearch}
+                      isLoading={isLoading}
+                      isDisabled={!searchQuery.trim() || !selectedRepo}
+                    >
+                      Search
+                    </Button>
+                  </div>
+                  
+                  <div className="max-h-80 overflow-y-auto">
+                    {isLoading ? (
+                      <div className="flex justify-center py-8">
+                        <Spinner size="lg" />
+                      </div>
+                    ) : searchResults.length > 0 ? (
+                      <div className="space-y-2">
+                        {searchResults.map((item) => (
+                          <Card
+                            key={item.id}
+                            isPressable
+                            onPress={() => handleLinkItem(item)}
+                            className="border border-gray-200 dark:border-gray-700"
+                          >
+                            <CardBody className="p-3">
+                              <div className="flex items-start">
+                                <div className="flex-1">
+                                  <div className="flex items-center mb-1">
+                                    <span className="text-sm font-medium text-gray-900 dark:text-gray-100">
+                                      #{item.number}
+                                    </span>
+                                    <span className="mx-2">•</span>
+                                    <span className="text-sm text-gray-600 dark:text-gray-400">
+                                      {new Date(item.created_at).toLocaleDateString()}
+                                    </span>
+                                  </div>
+                                  <h4 className="text-sm font-medium">{item.title}</h4>
+                                </div>
+                                <div className="ml-2">
+                                  <img
+                                    src={item.user.avatar_url}
+                                    alt={item.user.login}
+                                    className="w-6 h-6 rounded-full"
+                                  />
+                                </div>
+                              </div>
+                            </CardBody>
+                          </Card>
+                        ))}
+                      </div>
+                    ) : searchQuery ? (
+                      <div className="text-center py-8 text-gray-500 dark:text-gray-400">
+                        No results found
+                      </div>
+                    ) : (
+                      <div className="text-center py-8 text-gray-500 dark:text-gray-400">
+                        Search for {activeTab === "issues" ? "issues" : "pull requests"} to link
+                      </div>
+                    )}
+                  </div>
+                </div>
+              </ModalBody>
+              <ModalFooter>
+                <Button color="danger" variant="light" onPress={onClose}>
+                  Cancel
+                </Button>
+              </ModalFooter>
+            </>
+          )}
+        </ModalContent>
+      </Modal>
+    </div>
+  );
+}

--- a/app/projects/beta/[owner]/[number]/page.tsx
+++ b/app/projects/beta/[owner]/[number]/page.tsx
@@ -1,0 +1,387 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { useParams, useRouter } from "next/navigation";
+import Link from "next/link";
+import { useGitHub } from "../../../../context/GitHubContext";
+import MainLayout from "../../../../components/layout/MainLayout";
+import ProjectBetaBoard from "../../../../components/projects/ProjectBetaBoard";
+import {
+  Button,
+  Card,
+  CardBody,
+  CardHeader,
+  Chip,
+  Spinner,
+  Tabs,
+  Tab,
+  Textarea,
+  Input
+} from "@nextui-org/react";
+import { PencilIcon, TrashIcon, ArrowLeftIcon } from "@heroicons/react/24/outline";
+
+export default function ProjectBetaDetailPage() {
+  const params = useParams();
+  const router = useRouter();
+  const owner = params.owner as string;
+  const number = parseInt(params.number as string, 10);
+
+  const { githubService } = useGitHub();
+  const [project, setProject] = useState<any | null>(null);
+  const [projectItems, setProjectItems] = useState<any[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [isEditingTitle, setIsEditingTitle] = useState(false);
+  const [isEditingDescription, setIsEditingDescription] = useState(false);
+  const [projectTitle, setProjectTitle] = useState("");
+  const [projectDescription, setProjectDescription] = useState("");
+  const [activeView, setActiveView] = useState("board");
+
+  // Fetch project details
+  useEffect(() => {
+    async function fetchProjectDetails() {
+      if (!githubService) return;
+
+      try {
+        setIsLoading(true);
+        setError(null);
+
+        // Fetch project details
+        const projectData = await githubService.getProjectBeta(owner, number);
+        setProject(projectData);
+        setProjectTitle(projectData.title);
+        setProjectDescription(projectData.shortDescription || "");
+
+        // Fetch project items
+        const itemsData = await githubService.getProjectItems(projectData.id);
+        setProjectItems(itemsData);
+      } catch (err) {
+        console.error("Error fetching project details:", err);
+        setError("Failed to load project details. Please try again later.");
+      } finally {
+        setIsLoading(false);
+      }
+    }
+
+    fetchProjectDetails();
+  }, [githubService, owner, number]);
+
+  // Format date
+  const formatDate = (dateString: string) => {
+    const date = new Date(dateString);
+    return date.toLocaleDateString("en-US", {
+      year: "numeric",
+      month: "short",
+      day: "numeric",
+    });
+  };
+
+  // Handle item added
+  const handleItemAdded = async () => {
+    if (!githubService || !project) return;
+    
+    try {
+      setIsLoading(true);
+      const itemsData = await githubService.getProjectItems(project.id);
+      setProjectItems(itemsData);
+    } catch (error) {
+      console.error("Error refreshing project items:", error);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  // Handle item updated
+  const handleItemUpdated = async () => {
+    if (!githubService || !project) return;
+    
+    try {
+      setIsLoading(true);
+      const itemsData = await githubService.getProjectItems(project.id);
+      setProjectItems(itemsData);
+    } catch (error) {
+      console.error("Error refreshing project items:", error);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  if (isLoading && !project) {
+    return (
+      <MainLayout>
+        <div className="container mx-auto py-6">
+          <div className="flex justify-center items-center h-64">
+            <Spinner size="lg" />
+          </div>
+        </div>
+      </MainLayout>
+    );
+  }
+
+  if (error) {
+    return (
+      <MainLayout>
+        <div className="container mx-auto py-6">
+          <div className="bg-red-100 dark:bg-red-900 text-red-800 dark:text-red-200 p-4 rounded-md">
+            {error}
+          </div>
+          <div className="mt-4">
+            <Link href="/projects" className="text-blue-600 dark:text-blue-400 hover:underline">
+              ← Back to Projects
+            </Link>
+          </div>
+        </div>
+      </MainLayout>
+    );
+  }
+
+  if (!project) {
+    return (
+      <MainLayout>
+        <div className="container mx-auto py-6">
+          <div className="bg-yellow-100 dark:bg-yellow-900 text-yellow-800 dark:text-yellow-200 p-4 rounded-md">
+            Project not found.
+          </div>
+          <div className="mt-4">
+            <Link href="/projects" className="text-blue-600 dark:text-blue-400 hover:underline">
+              ← Back to Projects
+            </Link>
+          </div>
+        </div>
+      </MainLayout>
+    );
+  }
+
+  return (
+    <MainLayout>
+      <div className="container mx-auto py-6">
+        <div className="mb-6">
+          <div className="flex items-center space-x-2 text-sm text-gray-600 dark:text-gray-400 mb-2">
+            <Link href="/projects" className="hover:text-blue-600 dark:hover:text-blue-400 flex items-center">
+              <ArrowLeftIcon className="h-4 w-4 mr-1" />
+              Projects
+            </Link>
+            <span>/</span>
+            <span className="text-gray-900 dark:text-gray-200">{project.title}</span>
+          </div>
+
+          <div className="flex justify-between items-start">
+            <div className="flex-1">
+              {isEditingTitle ? (
+                <div className="mb-2">
+                  <Input
+                    value={projectTitle}
+                    onChange={(e) => setProjectTitle(e.target.value)}
+                    className="text-2xl font-bold"
+                    placeholder="Project title"
+                    autoFocus
+                  />
+                  <div className="flex mt-2 space-x-2">
+                    <Button
+                      color="primary"
+                      isDisabled={!projectTitle.trim()}
+                    >
+                      Save
+                    </Button>
+                    <Button
+                      color="default"
+                      variant="light"
+                      onPress={() => {
+                        setProjectTitle(project.title);
+                        setIsEditingTitle(false);
+                      }}
+                    >
+                      Cancel
+                    </Button>
+                  </div>
+                </div>
+              ) : (
+                <h1 className="text-2xl font-bold flex items-center">
+                  {project.title}
+                  <Button
+                    isIconOnly
+                    variant="light"
+                    onPress={() => setIsEditingTitle(true)}
+                    className="ml-2"
+                  >
+                    <PencilIcon className="h-4 w-4" />
+                  </Button>
+                </h1>
+              )}
+
+              <div className="mt-2 text-sm text-gray-600 dark:text-gray-400">
+                <Chip
+                  color={project.closed ? "danger" : "success"}
+                  size="sm"
+                >
+                  {project.closed ? "Closed" : "Open"}
+                </Chip>
+                <span className="mx-2">•</span>
+                <span>Created: {formatDate(project.createdAt)}</span>
+                <span className="mx-2">•</span>
+                <span>Updated: {formatDate(project.updatedAt)}</span>
+                <span className="mx-2">•</span>
+                <span>Creator: {project.creator.login}</span>
+              </div>
+            </div>
+
+            <div className="flex space-x-2">
+              <Button
+                as="a"
+                href={project.url}
+                target="_blank"
+                rel="noopener noreferrer"
+                variant="flat"
+                startContent={<svg className="h-4 w-4" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                  <path d="M10 6H6C4.89543 6 4 6.89543 4 8V18C4 19.1046 4.89543 20 6 20H16C17.1046 20 18 19.1046 18 18V14M14 4H20M20 4V10M20 4L10 14" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"/>
+                </svg>}
+              >
+                View on GitHub
+              </Button>
+            </div>
+          </div>
+
+          <div className="mt-4">
+            {isEditingDescription ? (
+              <div>
+                <Textarea
+                  value={projectDescription}
+                  onChange={(e) => setProjectDescription(e.target.value)}
+                  placeholder="Project description (optional)"
+                  minRows={3}
+                />
+                <div className="flex mt-2 space-x-2">
+                  <Button
+                    color="primary"
+                  >
+                    Save
+                  </Button>
+                  <Button
+                    color="default"
+                    variant="light"
+                    onPress={() => {
+                      setProjectDescription(project.shortDescription || "");
+                      setIsEditingDescription(false);
+                    }}
+                  >
+                    Cancel
+                  </Button>
+                </div>
+              </div>
+            ) : (
+              <div className="bg-gray-50 dark:bg-gray-900 p-4 rounded-md relative group">
+                {project.shortDescription ? (
+                  <div className="prose dark:prose-invert max-w-none">
+                    {project.shortDescription}
+                  </div>
+                ) : (
+                  <p className="text-gray-500 dark:text-gray-400 italic">
+                    No description provided.
+                  </p>
+                )}
+                <Button
+                  isIconOnly
+                  variant="light"
+                  onPress={() => setIsEditingDescription(true)}
+                  className="absolute top-2 right-2 opacity-0 group-hover:opacity-100 transition-opacity"
+                >
+                  <PencilIcon className="h-4 w-4" />
+                </Button>
+              </div>
+            )}
+          </div>
+        </div>
+
+        <div className="mt-8">
+          <Tabs
+            selectedKey={activeView}
+            onSelectionChange={(key) => setActiveView(key as string)}
+          >
+            <Tab key="board" title="Board">
+              <Card>
+                <CardBody>
+                  <ProjectBetaBoard
+                    projectId={project.id}
+                    fields={project.fields.nodes}
+                    items={projectItems}
+                    onItemAdded={handleItemAdded}
+                    onItemUpdated={handleItemUpdated}
+                  />
+                </CardBody>
+              </Card>
+            </Tab>
+            <Tab key="fields" title="Fields">
+              <Card>
+                <CardBody>
+                  <div className="space-y-4">
+                    <h3 className="text-lg font-medium">Project Fields</h3>
+                    <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                      {project.fields.nodes.map((field: any) => (
+                        <Card key={field.id} shadow="sm">
+                          <CardBody className="p-4">
+                            <div className="flex justify-between items-center">
+                              <div>
+                                <h4 className="font-medium">{field.name}</h4>
+                                <p className="text-sm text-gray-500 dark:text-gray-400">
+                                  Type: {field.dataType}
+                                </p>
+                              </div>
+                            </div>
+                            {field.dataType === "SINGLE_SELECT" && field.options && (
+                              <div className="mt-2">
+                                <p className="text-sm text-gray-600 dark:text-gray-400 mb-1">Options:</p>
+                                <div className="flex flex-wrap gap-1">
+                                  {field.options.map((option: any) => (
+                                    <Chip
+                                      key={option.id}
+                                      size="sm"
+                                      style={{
+                                        backgroundColor: `#${option.color}`,
+                                        color: parseInt(option.color, 16) > 0xffffff / 2 ? '#000' : '#fff'
+                                      }}
+                                    >
+                                      {option.name}
+                                    </Chip>
+                                  ))}
+                                </div>
+                              </div>
+                            )}
+                          </CardBody>
+                        </Card>
+                      ))}
+                    </div>
+                  </div>
+                </CardBody>
+              </Card>
+            </Tab>
+            <Tab key="views" title="Views">
+              <Card>
+                <CardBody>
+                  <div className="space-y-4">
+                    <h3 className="text-lg font-medium">Project Views</h3>
+                    <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                      {project.views.nodes.map((view: any) => (
+                        <Card key={view.id} shadow="sm">
+                          <CardBody className="p-4">
+                            <div className="flex justify-between items-center">
+                              <div>
+                                <h4 className="font-medium">{view.name}</h4>
+                                <p className="text-sm text-gray-500 dark:text-gray-400">
+                                  Layout: {view.layout}
+                                </p>
+                              </div>
+                            </div>
+                          </CardBody>
+                        </Card>
+                      ))}
+                    </div>
+                  </div>
+                </CardBody>
+              </Card>
+            </Tab>
+          </Tabs>
+        </div>
+      </div>
+    </MainLayout>
+  );
+}

--- a/app/services/github/githubService.ts
+++ b/app/services/github/githubService.ts
@@ -1,5 +1,15 @@
 import { Octokit } from "octokit";
 import { AuthCredentials, AuthMethod, AuthService } from "../auth/authService";
+import {
+  GET_USER_PROJECTS_BETA,
+  GET_ORG_PROJECTS_BETA,
+  GET_PROJECT_BETA,
+  GET_ORG_PROJECT_BETA,
+  GET_PROJECT_ITEMS,
+  ADD_ITEM_TO_PROJECT,
+  CREATE_DRAFT_ISSUE,
+  UPDATE_PROJECT_ITEM_FIELD
+} from "./queries/projectsQueries";
 
 export class GitHubService {
   // Make octokit public so components can access it directly
@@ -1068,5 +1078,92 @@ export class GitHubService {
       issue.title.toLowerCase().includes(lowerQuery) ||
       (issue.body && issue.body.toLowerCase().includes(lowerQuery))
     );
+  }
+
+  // GitHub Projects (beta) methods
+  async getUserProjectsBeta(username: string, first = 20) {
+    const { user } = await this.octokit.graphql(GET_USER_PROJECTS_BETA, {
+      login: username,
+      first
+    });
+    return user.projectsV2.nodes;
+  }
+
+  async getOrgProjectsBeta(org: string, first = 20) {
+    const { organization } = await this.octokit.graphql(GET_ORG_PROJECTS_BETA, {
+      org,
+      first
+    });
+    return organization.projectsV2.nodes;
+  }
+
+  async getAllUserProjectsBeta() {
+    const user = await this.getCurrentUser();
+    return this.getUserProjectsBeta(user.login);
+  }
+
+  async getAllOrgProjectsBeta() {
+    const orgs = await this.getUserOrganizations();
+    let allProjects: any[] = [];
+
+    for (const org of orgs) {
+      const projects = await this.getOrgProjectsBeta(org.login);
+      allProjects = [...allProjects, ...projects];
+    }
+
+    return allProjects;
+  }
+
+  async getProjectBeta(owner: string, number: number) {
+    try {
+      // Try to get as user project first
+      const { user } = await this.octokit.graphql(GET_PROJECT_BETA, {
+        owner,
+        number
+      });
+      return user.projectV2;
+    } catch (error) {
+      // If not found, try as org project
+      const { organization } = await this.octokit.graphql(GET_ORG_PROJECT_BETA, {
+        org: owner,
+        number
+      });
+      return organization.projectV2;
+    }
+  }
+
+  async getProjectItems(projectId: string, first = 100) {
+    const { node } = await this.octokit.graphql(GET_PROJECT_ITEMS, {
+      projectId,
+      first
+    });
+    return node.items.nodes;
+  }
+
+  async addItemToProject(projectId: string, contentId: string) {
+    const result = await this.octokit.graphql(ADD_ITEM_TO_PROJECT, {
+      projectId,
+      contentId
+    });
+    return result.addProjectV2ItemById.item;
+  }
+
+  async createDraftIssue(projectId: string, title: string, body?: string) {
+    const result = await this.octokit.graphql(CREATE_DRAFT_ISSUE, {
+      projectId,
+      title,
+      body
+    });
+    return result.addProjectV2DraftIssue.projectItem;
+  }
+
+  async updateProjectItemField(projectId: string, itemId: string, fieldId: string, value: string) {
+    const result = await this.octokit.graphql(UPDATE_PROJECT_ITEM_FIELD, {
+      projectId,
+      itemId,
+      fieldId,
+      value
+    });
+    return result.updateProjectV2ItemFieldValue.projectV2Item;
   }
 }

--- a/app/services/github/queries/projectsQueries.ts
+++ b/app/services/github/queries/projectsQueries.ts
@@ -1,0 +1,292 @@
+/**
+ * GraphQL queries for GitHub Projects (beta)
+ */
+
+// Query to get a list of projects (beta) for the authenticated user
+export const GET_USER_PROJECTS_BETA = `
+  query GetUserProjectsBeta($login: String!, $first: Int!) {
+    user(login: $login) {
+      projectsV2(first: $first) {
+        nodes {
+          id
+          title
+          number
+          shortDescription
+          url
+          closed
+          createdAt
+          updatedAt
+          creator {
+            login
+            avatarUrl
+          }
+        }
+      }
+    }
+  }
+`;
+
+// Query to get a list of projects (beta) for an organization
+export const GET_ORG_PROJECTS_BETA = `
+  query GetOrgProjectsBeta($org: String!, $first: Int!) {
+    organization(login: $org) {
+      projectsV2(first: $first) {
+        nodes {
+          id
+          title
+          number
+          shortDescription
+          url
+          closed
+          createdAt
+          updatedAt
+          creator {
+            login
+            avatarUrl
+          }
+        }
+      }
+    }
+  }
+`;
+
+// Query to get a single project (beta) by number
+export const GET_PROJECT_BETA = `
+  query GetProjectBeta($owner: String!, $number: Int!) {
+    user(login: $owner) {
+      projectV2(number: $number) {
+        id
+        title
+        number
+        shortDescription
+        url
+        closed
+        createdAt
+        updatedAt
+        creator {
+          login
+          avatarUrl
+        }
+        fields(first: 20) {
+          nodes {
+            ... on ProjectV2Field {
+              id
+              name
+              dataType
+            }
+            ... on ProjectV2IterationField {
+              id
+              name
+              dataType
+              configuration {
+                iterations {
+                  startDate
+                  endDate
+                }
+                duration
+                completedIterations
+              }
+            }
+            ... on ProjectV2SingleSelectField {
+              id
+              name
+              dataType
+              options {
+                id
+                name
+                color
+              }
+            }
+          }
+        }
+        views(first: 10) {
+          nodes {
+            id
+            name
+            layout
+          }
+        }
+      }
+    }
+  }
+`;
+
+// Query to get a single organization project (beta) by number
+export const GET_ORG_PROJECT_BETA = `
+  query GetOrgProjectBeta($org: String!, $number: Int!) {
+    organization(login: $org) {
+      projectV2(number: $number) {
+        id
+        title
+        number
+        shortDescription
+        url
+        closed
+        createdAt
+        updatedAt
+        creator {
+          login
+          avatarUrl
+        }
+        fields(first: 20) {
+          nodes {
+            ... on ProjectV2Field {
+              id
+              name
+              dataType
+            }
+            ... on ProjectV2IterationField {
+              id
+              name
+              dataType
+              configuration {
+                iterations {
+                  startDate
+                  endDate
+                }
+                duration
+                completedIterations
+              }
+            }
+            ... on ProjectV2SingleSelectField {
+              id
+              name
+              dataType
+              options {
+                id
+                name
+                color
+              }
+            }
+          }
+        }
+        views(first: 10) {
+          nodes {
+            id
+            name
+            layout
+          }
+        }
+      }
+    }
+  }
+`;
+
+// Query to get project items (cards)
+export const GET_PROJECT_ITEMS = `
+  query GetProjectItems($projectId: ID!, $first: Int!) {
+    node(id: $projectId) {
+      ... on ProjectV2 {
+        items(first: $first) {
+          nodes {
+            id
+            fieldValues(first: 20) {
+              nodes {
+                ... on ProjectV2ItemFieldTextValue {
+                  text
+                  field {
+                    ... on ProjectV2FieldCommon {
+                      name
+                    }
+                  }
+                }
+                ... on ProjectV2ItemFieldDateValue {
+                  date
+                  field {
+                    ... on ProjectV2FieldCommon {
+                      name
+                    }
+                  }
+                }
+                ... on ProjectV2ItemFieldSingleSelectValue {
+                  name
+                  field {
+                    ... on ProjectV2FieldCommon {
+                      name
+                    }
+                  }
+                }
+              }
+            }
+            content {
+              ... on Issue {
+                id
+                title
+                number
+                state
+                repository {
+                  name
+                  owner {
+                    login
+                  }
+                }
+              }
+              ... on PullRequest {
+                id
+                title
+                number
+                state
+                repository {
+                  name
+                  owner {
+                    login
+                  }
+                }
+              }
+              ... on DraftIssue {
+                id
+                title
+                body
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+`;
+
+// Mutation to add an item (issue or PR) to a project
+export const ADD_ITEM_TO_PROJECT = `
+  mutation AddItemToProject($projectId: ID!, $contentId: ID!) {
+    addProjectV2ItemById(input: {
+      projectId: $projectId,
+      contentId: $contentId
+    }) {
+      item {
+        id
+      }
+    }
+  }
+`;
+
+// Mutation to create a draft issue in a project
+export const CREATE_DRAFT_ISSUE = `
+  mutation CreateDraftIssue($projectId: ID!, $title: String!, $body: String) {
+    addProjectV2DraftIssue(input: {
+      projectId: $projectId,
+      title: $title,
+      body: $body
+    }) {
+      projectItem {
+        id
+      }
+    }
+  }
+`;
+
+// Mutation to update a project field value
+export const UPDATE_PROJECT_ITEM_FIELD = `
+  mutation UpdateProjectItemField($projectId: ID!, $itemId: ID!, $fieldId: ID!, $value: String!) {
+    updateProjectV2ItemFieldValue(input: {
+      projectId: $projectId,
+      itemId: $itemId,
+      fieldId: $fieldId,
+      value: $value
+    }) {
+      projectV2Item {
+        id
+      }
+    }
+  }
+`;


### PR DESCRIPTION
This PR adds support for GitHub Projects (beta) using the GraphQL API. 

## Features
- Added GraphQL queries for GitHub Projects (beta)
- Extended GitHubService with methods for GitHub Projects (beta)
- Created ProjectBetaBoard component for displaying project items
- Added a new page for viewing GitHub Projects (beta) details
- Updated the projects page to include a tab for GitHub Projects (beta)

## Testing
- Tested with GitHub user and organization projects
- Verified project items display correctly
- Verified adding items to projects works correctly