### PR TITLE
Add GitHub Discussions integration

### DIFF
--- a/app/components/discussions/CreateDiscussionModal.tsx
+++ b/app/components/discussions/CreateDiscussionModal.tsx
@@ -1,0 +1,191 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { useGitHub } from "../../context/GitHubContext";
+import {
+  Modal,
+  ModalContent,
+  ModalHeader,
+  ModalBody,
+  ModalFooter,
+  Button,
+  Input,
+  Textarea,
+  Select,
+  SelectItem,
+  Spinner
+} from "@nextui-org/react";
+
+interface CreateDiscussionModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  owner: string;
+  repo: string;
+  onDiscussionCreated: (discussionNumber: number) => void;
+}
+
+export default function CreateDiscussionModal({
+  isOpen,
+  onClose,
+  owner,
+  repo,
+  onDiscussionCreated
+}: CreateDiscussionModalProps) {
+  const { githubService } = useGitHub();
+  const [title, setTitle] = useState("");
+  const [body, setBody] = useState("");
+  const [categoryId, setCategoryId] = useState("");
+  const [categories, setCategories] = useState<any[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // Fetch discussion categories
+  useEffect(() => {
+    async function fetchCategories() {
+      if (!githubService || !isOpen) return;
+      
+      try {
+        setIsLoading(true);
+        setError(null);
+        
+        const categoriesData = await githubService.getDiscussionCategories(owner, repo);
+        setCategories(categoriesData);
+        
+        // Set default category if available
+        if (categoriesData.length > 0) {
+          setCategoryId(categoriesData[0].id);
+        }
+      } catch (err) {
+        console.error("Error fetching discussion categories:", err);
+        setError("Failed to fetch discussion categories. Please try again later.");
+      } finally {
+        setIsLoading(false);
+      }
+    }
+    
+    fetchCategories();
+  }, [githubService, owner, repo, isOpen]);
+
+  // Reset form when modal is closed
+  useEffect(() => {
+    if (!isOpen) {
+      setTitle("");
+      setBody("");
+      setCategoryId("");
+      setError(null);
+    }
+  }, [isOpen]);
+
+  // Handle create discussion
+  const handleCreateDiscussion = async () => {
+    if (!githubService || !title.trim() || !body.trim() || !categoryId) return;
+    
+    try {
+      setIsSubmitting(true);
+      setError(null);
+      
+      // Get repository ID
+      const repositoryId = await githubService.getRepositoryIdByName(owner, repo);
+      
+      // Create discussion
+      const discussion = await githubService.createDiscussion({
+        repositoryId,
+        categoryId,
+        title,
+        body
+      });
+      
+      // Close modal and notify parent
+      onClose();
+      onDiscussionCreated(discussion.number);
+    } catch (err) {
+      console.error("Error creating discussion:", err);
+      setError("Failed to create discussion. Please try again.");
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} size="2xl">
+      <ModalContent>
+        {(onClose) => (
+          <>
+            <ModalHeader>Create a new discussion</ModalHeader>
+            <ModalBody>
+              {isLoading ? (
+                <div className="flex justify-center items-center h-40">
+                  <Spinner size="lg" />
+                </div>
+              ) : error ? (
+                <div className="bg-red-100 dark:bg-red-900 text-red-800 dark:text-red-200 p-4 rounded-md mb-4">
+                  {error}
+                </div>
+              ) : (
+                <div className="space-y-4">
+                  <Input
+                    label="Title"
+                    placeholder="Enter a title for your discussion"
+                    value={title}
+                    onChange={(e) => setTitle(e.target.value)}
+                    isRequired
+                  />
+                  
+                  <Select
+                    label="Category"
+                    placeholder="Select a category"
+                    selectedKeys={categoryId ? [categoryId] : []}
+                    onChange={(e) => setCategoryId(e.target.value)}
+                    isRequired
+                  >
+                    {categories.map((category) => (
+                      <SelectItem key={category.id} value={category.id}>
+                        {category.emoji} {category.name}
+                      </SelectItem>
+                    ))}
+                  </Select>
+                  
+                  <Textarea
+                    label="Body"
+                    placeholder="Write your discussion here... (Markdown supported)"
+                    value={body}
+                    onChange={(e) => setBody(e.target.value)}
+                    minRows={10}
+                    isRequired
+                  />
+                  
+                  <div className="text-xs text-gray-500 dark:text-gray-400">
+                    <p>Markdown formatting supported:</p>
+                    <ul className="list-disc pl-4 mt-1">
+                      <li>**bold** or __bold__</li>
+                      <li>*italic* or _italic_</li>
+                      <li># Heading 1, ## Heading 2, etc.</li>
+                      <li>[Link text](URL)</li>
+                      <li>- Bullet points</li>
+                      <li>1. Numbered lists</li>
+                      <li>```code blocks```</li>
+                    </ul>
+                  </div>
+                </div>
+              )}
+            </ModalBody>
+            <ModalFooter>
+              <Button variant="flat" onPress={onClose}>
+                Cancel
+              </Button>
+              <Button
+                color="primary"
+                onPress={handleCreateDiscussion}
+                isLoading={isSubmitting}
+                isDisabled={isLoading || !title.trim() || !body.trim() || !categoryId}
+              >
+                Create Discussion
+              </Button>
+            </ModalFooter>
+          </>
+        )}
+      </ModalContent>
+    </Modal>
+  );
+}

--- a/app/components/discussions/DiscussionDetail.tsx
+++ b/app/components/discussions/DiscussionDetail.tsx
@@ -1,0 +1,520 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { useGitHub } from "../../context/GitHubContext";
+import Link from "next/link";
+import {
+  Card,
+  CardBody,
+  CardHeader,
+  CardFooter,
+  Button,
+  Spinner,
+  Chip,
+  Divider,
+  Textarea,
+  Avatar,
+  Pagination,
+  Dropdown,
+  DropdownTrigger,
+  DropdownMenu,
+  DropdownItem
+} from "@nextui-org/react";
+import {
+  ChatBubbleLeftRightIcon,
+  CheckCircleIcon,
+  ClockIcon,
+  UserCircleIcon,
+  PaperAirplaneIcon,
+  EllipsisVerticalIcon,
+  PencilIcon,
+  TrashIcon,
+  FlagIcon,
+  HandThumbUpIcon,
+  HandThumbDownIcon,
+  FaceSmileIcon,
+  HeartIcon,
+  RocketLaunchIcon,
+  EyeIcon
+} from "@heroicons/react/24/outline";
+import ReactMarkdown from 'react-markdown';
+
+interface DiscussionDetailProps {
+  owner: string;
+  repo: string;
+  discussionNumber: number;
+}
+
+export default function DiscussionDetail({ owner, repo, discussionNumber }: DiscussionDetailProps) {
+  const { githubService } = useGitHub();
+  const [discussion, setDiscussion] = useState<any | null>(null);
+  const [comments, setComments] = useState<any[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [isLoadingComments, setIsLoadingComments] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [commentText, setCommentText] = useState("");
+  const [page, setPage] = useState(1);
+  const [totalComments, setTotalComments] = useState(0);
+  const [hasNextPage, setHasNextPage] = useState(false);
+  const [endCursor, setEndCursor] = useState<string | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const itemsPerPage = 10;
+
+  // Fetch discussion details
+  useEffect(() => {
+    async function fetchDiscussionDetails() {
+      if (!githubService) return;
+      
+      try {
+        setIsLoading(true);
+        setError(null);
+        
+        // Get discussion
+        const discussionData = await githubService.getDiscussion(owner, repo, discussionNumber);
+        setDiscussion(discussionData);
+        
+        // Get comments
+        await fetchComments();
+      } catch (err) {
+        console.error("Error fetching discussion:", err);
+        setError("Failed to fetch discussion. Please try again later.");
+      } finally {
+        setIsLoading(false);
+      }
+    }
+    
+    fetchDiscussionDetails();
+  }, [githubService, owner, repo, discussionNumber]);
+
+  // Fetch comments when page changes
+  useEffect(() => {
+    if (discussion) {
+      fetchComments();
+    }
+  }, [page]);
+
+  // Fetch comments
+  async function fetchComments() {
+    if (!githubService) return;
+    
+    try {
+      setIsLoadingComments(true);
+      
+      const commentsData = await githubService.getDiscussionComments(
+        owner,
+        repo,
+        discussionNumber,
+        itemsPerPage,
+        page > 1 ? endCursor : undefined
+      );
+      
+      setComments(commentsData.nodes);
+      setTotalComments(commentsData.totalCount);
+      setHasNextPage(commentsData.pageInfo.hasNextPage);
+      setEndCursor(commentsData.pageInfo.endCursor);
+    } catch (err) {
+      console.error("Error fetching comments:", err);
+    } finally {
+      setIsLoadingComments(false);
+    }
+  }
+
+  // Format date
+  const formatDate = (dateString: string) => {
+    const date = new Date(dateString);
+    return date.toLocaleDateString("en-US", {
+      year: "numeric",
+      month: "short",
+      day: "numeric",
+      hour: "2-digit",
+      minute: "2-digit"
+    });
+  };
+
+  // Handle submit comment
+  const handleSubmitComment = async () => {
+    if (!githubService || !discussion || !commentText.trim()) return;
+    
+    try {
+      setIsSubmitting(true);
+      
+      await githubService.addDiscussionComment({
+        discussionId: discussion.id,
+        body: commentText
+      });
+      
+      // Reset form and refresh comments
+      setCommentText("");
+      setPage(1);
+      setEndCursor(null);
+      await fetchComments();
+    } catch (err) {
+      console.error("Error submitting comment:", err);
+      alert("Failed to submit comment. Please try again.");
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  // Handle mark as answer
+  const handleMarkAsAnswer = async (commentId: string) => {
+    if (!githubService || !discussion) return;
+    
+    try {
+      await githubService.markDiscussionCommentAsAnswer({
+        commentId
+      });
+      
+      // Refresh discussion and comments
+      const discussionData = await githubService.getDiscussion(owner, repo, discussionNumber);
+      setDiscussion(discussionData);
+      await fetchComments();
+    } catch (err) {
+      console.error("Error marking as answer:", err);
+      alert("Failed to mark as answer. Please try again.");
+    }
+  };
+
+  // Handle unmark as answer
+  const handleUnmarkAsAnswer = async (commentId: string) => {
+    if (!githubService || !discussion) return;
+    
+    try {
+      await githubService.unmarkDiscussionCommentAsAnswer({
+        commentId
+      });
+      
+      // Refresh discussion and comments
+      const discussionData = await githubService.getDiscussion(owner, repo, discussionNumber);
+      setDiscussion(discussionData);
+      await fetchComments();
+    } catch (err) {
+      console.error("Error unmarking as answer:", err);
+      alert("Failed to unmark as answer. Please try again.");
+    }
+  };
+
+  // Handle add reaction
+  const handleAddReaction = async (subjectId: string, content: string) => {
+    if (!githubService) return;
+    
+    try {
+      await githubService.addReaction({
+        subjectId,
+        content: content as any
+      });
+      
+      // Refresh comments
+      await fetchComments();
+    } catch (err) {
+      console.error("Error adding reaction:", err);
+      alert("Failed to add reaction. Please try again.");
+    }
+  };
+
+  if (isLoading) {
+    return (
+      <div className="flex justify-center items-center h-64">
+        <Spinner size="lg" />
+      </div>
+    );
+  }
+
+  if (error || !discussion) {
+    return (
+      <div className="bg-red-100 dark:bg-red-900 text-red-800 dark:text-red-200 p-4 rounded-md">
+        {error || "Discussion not found."}
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      <Card className="overflow-visible">
+        <CardHeader className="flex flex-col items-start gap-2 pb-0">
+          <div className="flex items-center gap-2">
+            <Chip size="sm" variant="flat" color="primary">
+              {discussion.category.emoji} {discussion.category.name}
+            </Chip>
+            {discussion.answerChosenAt && (
+              <Chip size="sm" variant="flat" color="success" startContent={<CheckCircleIcon className="h-3 w-3" />}>
+                Answered
+              </Chip>
+            )}
+          </div>
+          <h1 className="text-2xl font-bold">{discussion.title}</h1>
+          <div className="flex items-center gap-4 text-sm text-gray-500 dark:text-gray-400">
+            <div className="flex items-center">
+              <Avatar src={discussion.author.avatarUrl} size="sm" className="mr-2" />
+              {discussion.author.login}
+            </div>
+            <div className="flex items-center">
+              <ClockIcon className="h-4 w-4 mr-1" />
+              {formatDate(discussion.createdAt)}
+            </div>
+          </div>
+        </CardHeader>
+        <CardBody className="py-4">
+          <div className="prose dark:prose-invert max-w-none">
+            <ReactMarkdown>{discussion.body}</ReactMarkdown>
+          </div>
+        </CardBody>
+        <CardFooter className="flex justify-between items-center pt-0">
+          <div className="flex items-center gap-2">
+            <Button
+              size="sm"
+              variant="light"
+              startContent={<HandThumbUpIcon className="h-4 w-4" />}
+              onPress={() => handleAddReaction(discussion.id, "THUMBS_UP")}
+            >
+              Like
+            </Button>
+            <Button
+              size="sm"
+              variant="light"
+              startContent={<FaceSmileIcon className="h-4 w-4" />}
+              onPress={() => handleAddReaction(discussion.id, "LAUGH")}
+            >
+              Laugh
+            </Button>
+            <Button
+              size="sm"
+              variant="light"
+              startContent={<HeartIcon className="h-4 w-4" />}
+              onPress={() => handleAddReaction(discussion.id, "HEART")}
+            >
+              Heart
+            </Button>
+          </div>
+          <Button
+            as="a"
+            href={discussion.url}
+            target="_blank"
+            rel="noopener noreferrer"
+            size="sm"
+            variant="flat"
+          >
+            View on GitHub
+          </Button>
+        </CardFooter>
+      </Card>
+
+      <div className="flex items-center justify-between">
+        <h2 className="text-xl font-semibold">
+          Comments ({totalComments})
+        </h2>
+        <div className="flex items-center gap-2">
+          <Button
+            size="sm"
+            variant="flat"
+            onPress={() => {
+              setPage(1);
+              setEndCursor(null);
+              fetchComments();
+            }}
+          >
+            Refresh
+          </Button>
+        </div>
+      </div>
+
+      {isLoadingComments && page === 1 ? (
+        <div className="flex justify-center items-center h-32">
+          <Spinner size="md" />
+        </div>
+      ) : comments.length > 0 ? (
+        <div className="space-y-4">
+          {comments.map((comment) => (
+            <Card key={comment.id} className={comment.isAnswer ? "border-2 border-green-500" : ""}>
+              <CardHeader className="flex justify-between items-start pb-0">
+                <div className="flex items-center gap-2">
+                  <Avatar src={comment.author.avatarUrl} size="sm" />
+                  <div>
+                    <div className="font-medium">{comment.author.login}</div>
+                    <div className="text-xs text-gray-500 dark:text-gray-400">
+                      {formatDate(comment.createdAt)}
+                    </div>
+                  </div>
+                </div>
+                <div className="flex items-center gap-2">
+                  {comment.isAnswer && (
+                    <Chip color="success" size="sm" startContent={<CheckCircleIcon className="h-3 w-3" />}>
+                      Answer
+                    </Chip>
+                  )}
+                  <Dropdown>
+                    <DropdownTrigger>
+                      <Button isIconOnly size="sm" variant="light">
+                        <EllipsisVerticalIcon className="h-4 w-4" />
+                      </Button>
+                    </DropdownTrigger>
+                    <DropdownMenu aria-label="Comment actions">
+                      {discussion.category.isAnswerable && (
+                        comment.isAnswer ? (
+                          <DropdownItem
+                            key="unmark-answer"
+                            startContent={<CheckCircleIcon className="h-4 w-4" />}
+                            onPress={() => handleUnmarkAsAnswer(comment.id)}
+                          >
+                            Unmark as answer
+                          </DropdownItem>
+                        ) : (
+                          <DropdownItem
+                            key="mark-answer"
+                            startContent={<CheckCircleIcon className="h-4 w-4" />}
+                            onPress={() => handleMarkAsAnswer(comment.id)}
+                          >
+                            Mark as answer
+                          </DropdownItem>
+                        )
+                      )}
+                      <DropdownItem
+                        key="copy-link"
+                        startContent={<LinkIcon className="h-4 w-4" />}
+                      >
+                        Copy link
+                      </DropdownItem>
+                      <DropdownItem
+                        key="report"
+                        startContent={<FlagIcon className="h-4 w-4" />}
+                        className="text-danger"
+                      >
+                        Report
+                      </DropdownItem>
+                    </DropdownMenu>
+                  </Dropdown>
+                </div>
+              </CardHeader>
+              <CardBody className="py-4">
+                <div className="prose dark:prose-invert max-w-none">
+                  <ReactMarkdown>{comment.body}</ReactMarkdown>
+                </div>
+              </CardBody>
+              <CardFooter className="flex justify-between items-center pt-0">
+                <div className="flex items-center gap-2">
+                  {comment.reactionGroups.map((reaction: any) => (
+                    reaction.users.totalCount > 0 && (
+                      <Chip key={reaction.content} size="sm" variant="flat">
+                        {getReactionEmoji(reaction.content)} {reaction.users.totalCount}
+                      </Chip>
+                    )
+                  ))}
+                </div>
+                <div className="flex items-center gap-2">
+                  <Button
+                    size="sm"
+                    variant="light"
+                    startContent={<HandThumbUpIcon className="h-4 w-4" />}
+                    onPress={() => handleAddReaction(comment.id, "THUMBS_UP")}
+                  >
+                    Like
+                  </Button>
+                </div>
+              </CardFooter>
+              
+              {comment.replies.totalCount > 0 && (
+                <div className="px-6 pb-4">
+                  <Divider className="my-2" />
+                  <div className="text-sm font-medium mb-2">
+                    Replies ({comment.replies.totalCount})
+                  </div>
+                  <div className="space-y-3 pl-4 border-l-2 border-gray-200 dark:border-gray-700">
+                    {comment.replies.nodes.map((reply: any) => (
+                      <div key={reply.id} className="text-sm">
+                        <div className="flex items-center gap-2 mb-1">
+                          <Avatar src={reply.author.avatarUrl} size="sm" />
+                          <div className="font-medium">{reply.author.login}</div>
+                          <div className="text-xs text-gray-500 dark:text-gray-400">
+                            {formatDate(reply.createdAt)}
+                          </div>
+                        </div>
+                        <div className="pl-8">
+                          <ReactMarkdown>{reply.body}</ReactMarkdown>
+                        </div>
+                      </div>
+                    ))}
+                    {comment.replies.totalCount > 3 && (
+                      <Button
+                        size="sm"
+                        variant="light"
+                        className="ml-8"
+                        as="a"
+                        href={`${discussion.url}#discussioncomment-${comment.id.split('_')[1]}`}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        View all replies
+                      </Button>
+                    )}
+                  </div>
+                </div>
+              )}
+            </Card>
+          ))}
+          
+          {totalComments > itemsPerPage && (
+            <div className="flex justify-center mt-6">
+              <Pagination
+                total={Math.ceil(totalComments / itemsPerPage)}
+                page={page}
+                onChange={setPage}
+                showControls
+              />
+            </div>
+          )}
+        </div>
+      ) : (
+        <Card>
+          <CardBody className="py-6">
+            <div className="text-center">
+              <ChatBubbleLeftRightIcon className="h-12 w-12 mx-auto text-gray-400 dark:text-gray-600 mb-3" />
+              <p className="text-gray-500 dark:text-gray-400">
+                No comments yet. Be the first to comment!
+              </p>
+            </div>
+          </CardBody>
+        </Card>
+      )}
+
+      <Card>
+        <CardHeader>
+          <h3 className="text-lg font-medium">Add a comment</h3>
+        </CardHeader>
+        <CardBody>
+          <Textarea
+            placeholder="Write your comment here... (Markdown supported)"
+            value={commentText}
+            onChange={(e) => setCommentText(e.target.value)}
+            minRows={4}
+          />
+        </CardBody>
+        <CardFooter>
+          <Button
+            color="primary"
+            startContent={<PaperAirplaneIcon className="h-4 w-4" />}
+            onPress={handleSubmitComment}
+            isLoading={isSubmitting}
+            isDisabled={!commentText.trim()}
+          >
+            Submit
+          </Button>
+        </CardFooter>
+      </Card>
+    </div>
+  );
+}
+
+// Helper function to get reaction emoji
+function getReactionEmoji(content: string) {
+  switch (content) {
+    case 'THUMBS_UP': return '👍';
+    case 'THUMBS_DOWN': return '👎';
+    case 'LAUGH': return '😄';
+    case 'HOORAY': return '🎉';
+    case 'CONFUSED': return '😕';
+    case 'HEART': return '❤️';
+    case 'ROCKET': return '🚀';
+    case 'EYES': return '👀';
+    default: return '👍';
+  }
+}

--- a/app/components/discussions/DiscussionList.tsx
+++ b/app/components/discussions/DiscussionList.tsx
@@ -1,0 +1,307 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { useGitHub } from "../../context/GitHubContext";
+import Link from "next/link";
+import {
+  Card,
+  CardBody,
+  CardHeader,
+  Button,
+  Spinner,
+  Chip,
+  Pagination,
+  Input,
+  Select,
+  SelectItem,
+  Dropdown,
+  DropdownTrigger,
+  DropdownMenu,
+  DropdownItem
+} from "@nextui-org/react";
+import {
+  ChatBubbleLeftRightIcon,
+  MagnifyingGlassIcon,
+  FunnelIcon,
+  PlusIcon,
+  CheckCircleIcon,
+  ClockIcon,
+  UserCircleIcon,
+  ArrowPathIcon
+} from "@heroicons/react/24/outline";
+
+interface DiscussionListProps {
+  owner: string;
+  repo: string;
+  onCreateDiscussion?: () => void;
+}
+
+export default function DiscussionList({ owner, repo, onCreateDiscussion }: DiscussionListProps) {
+  const { githubService } = useGitHub();
+  const [discussions, setDiscussions] = useState<any[]>([]);
+  const [categories, setCategories] = useState<any[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [page, setPage] = useState(1);
+  const [totalCount, setTotalCount] = useState(0);
+  const [hasNextPage, setHasNextPage] = useState(false);
+  const [endCursor, setEndCursor] = useState<string | null>(null);
+  const [searchQuery, setSearchQuery] = useState("");
+  const [selectedCategory, setSelectedCategory] = useState<string>("all");
+  const [sortBy, setSortBy] = useState<string>("newest");
+  const itemsPerPage = 10;
+
+  // Fetch discussions
+  useEffect(() => {
+    async function fetchDiscussions() {
+      if (!githubService) return;
+      
+      try {
+        setIsLoading(true);
+        setError(null);
+        
+        // Get discussions
+        const discussionsData = await githubService.getRepositoryDiscussions(
+          owner, 
+          repo, 
+          itemsPerPage,
+          page > 1 ? endCursor : undefined
+        );
+        
+        setDiscussions(discussionsData.nodes);
+        setTotalCount(discussionsData.totalCount);
+        setHasNextPage(discussionsData.pageInfo.hasNextPage);
+        setEndCursor(discussionsData.pageInfo.endCursor);
+        
+        // Get categories
+        const categoriesData = await githubService.getDiscussionCategories(owner, repo);
+        setCategories(categoriesData);
+      } catch (err) {
+        console.error("Error fetching discussions:", err);
+        setError("Failed to fetch discussions. Please try again later.");
+      } finally {
+        setIsLoading(false);
+      }
+    }
+    
+    fetchDiscussions();
+  }, [githubService, owner, repo, page]);
+
+  // Format date
+  const formatDate = (dateString: string) => {
+    const date = new Date(dateString);
+    return date.toLocaleDateString("en-US", {
+      year: "numeric",
+      month: "short",
+      day: "numeric",
+    });
+  };
+
+  // Handle search
+  const handleSearch = () => {
+    // Reset pagination
+    setPage(1);
+    setEndCursor(null);
+    
+    // Fetch discussions with search query
+    // Note: GitHub GraphQL API doesn't support searching discussions directly
+    // This would need to be implemented with a combination of REST API calls
+    // or by filtering the results client-side
+  };
+
+  // Handle category filter
+  const handleCategoryFilter = (categoryId: string) => {
+    setSelectedCategory(categoryId);
+    setPage(1);
+    setEndCursor(null);
+    
+    // Fetch discussions with category filter
+    // Note: This would need to be implemented with additional filtering in the GraphQL query
+  };
+
+  // Handle sort
+  const handleSort = (sortOption: string) => {
+    setSortBy(sortOption);
+    setPage(1);
+    setEndCursor(null);
+    
+    // Fetch discussions with sort option
+    // Note: This would need to be implemented with additional sorting in the GraphQL query
+  };
+
+  // Filter discussions by category
+  const filteredDiscussions = selectedCategory === "all"
+    ? discussions
+    : discussions.filter(discussion => discussion.category.id === selectedCategory);
+
+  // Sort discussions
+  const sortedDiscussions = [...filteredDiscussions].sort((a, b) => {
+    if (sortBy === "newest") {
+      return new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime();
+    } else if (sortBy === "oldest") {
+      return new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime();
+    } else if (sortBy === "most-comments") {
+      return b.comments.totalCount - a.comments.totalCount;
+    } else if (sortBy === "recently-updated") {
+      return new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime();
+    }
+    return 0;
+  });
+
+  if (isLoading && page === 1) {
+    return (
+      <div className="flex justify-center items-center h-64">
+        <Spinner size="lg" />
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="bg-red-100 dark:bg-red-900 text-red-800 dark:text-red-200 p-4 rounded-md">
+        {error}
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="flex flex-col sm:flex-row justify-between items-start sm:items-center gap-4">
+        <h2 className="text-xl font-semibold">Discussions</h2>
+        <Button
+          color="primary"
+          startContent={<PlusIcon className="h-4 w-4" />}
+          onPress={onCreateDiscussion}
+        >
+          New Discussion
+        </Button>
+      </div>
+      
+      <div className="flex flex-col md:flex-row gap-4">
+        <div className="flex-1">
+          <Input
+            placeholder="Search discussions..."
+            value={searchQuery}
+            onChange={(e) => setSearchQuery(e.target.value)}
+            onKeyDown={(e) => e.key === "Enter" && handleSearch()}
+            startContent={<MagnifyingGlassIcon className="h-5 w-5 text-gray-400" />}
+            className="w-full"
+          />
+        </div>
+        
+        <div className="flex gap-2">
+          <Select
+            placeholder="Category"
+            selectedKeys={[selectedCategory]}
+            onChange={(e) => handleCategoryFilter(e.target.value)}
+            className="w-40"
+          >
+            <SelectItem key="all" value="all">All Categories</SelectItem>
+            {categories.map((category) => (
+              <SelectItem key={category.id} value={category.id}>
+                {category.emoji} {category.name}
+              </SelectItem>
+            ))}
+          </Select>
+          
+          <Select
+            placeholder="Sort by"
+            selectedKeys={[sortBy]}
+            onChange={(e) => handleSort(e.target.value)}
+            className="w-40"
+          >
+            <SelectItem key="newest" value="newest">Newest</SelectItem>
+            <SelectItem key="oldest" value="oldest">Oldest</SelectItem>
+            <SelectItem key="most-comments" value="most-comments">Most Comments</SelectItem>
+            <SelectItem key="recently-updated" value="recently-updated">Recently Updated</SelectItem>
+          </Select>
+        </div>
+      </div>
+      
+      {sortedDiscussions.length > 0 ? (
+        <div className="space-y-4">
+          {sortedDiscussions.map((discussion) => (
+            <Card key={discussion.id} className="hover:shadow-md transition-shadow">
+              <CardBody className="p-4">
+                <div className="flex items-start gap-4">
+                  <div className="flex-shrink-0">
+                    <img
+                      src={discussion.author.avatarUrl}
+                      alt={discussion.author.login}
+                      className="w-10 h-10 rounded-full"
+                    />
+                  </div>
+                  <div className="flex-1 min-w-0">
+                    <div className="flex items-center gap-2 mb-1">
+                      <Chip size="sm" variant="flat" color="primary">
+                        {discussion.category.emoji} {discussion.category.name}
+                      </Chip>
+                      {discussion.answerChosenAt && (
+                        <Chip size="sm" variant="flat" color="success" startContent={<CheckCircleIcon className="h-3 w-3" />}>
+                          Answered
+                        </Chip>
+                      )}
+                    </div>
+                    <Link
+                      href={`/repositories/${owner}/${repo}/discussions/${discussion.number}`}
+                      className="text-lg font-medium hover:text-blue-600 dark:hover:text-blue-400 line-clamp-1"
+                    >
+                      {discussion.title}
+                    </Link>
+                    <p className="text-gray-600 dark:text-gray-400 text-sm line-clamp-2 mt-1">
+                      {discussion.body.replace(/\r?\n|\r/g, ' ').substring(0, 150)}
+                      {discussion.body.length > 150 ? '...' : ''}
+                    </p>
+                    <div className="flex items-center gap-4 mt-2 text-xs text-gray-500 dark:text-gray-400">
+                      <div className="flex items-center">
+                        <UserCircleIcon className="h-4 w-4 mr-1" />
+                        {discussion.author.login}
+                      </div>
+                      <div className="flex items-center">
+                        <ClockIcon className="h-4 w-4 mr-1" />
+                        {formatDate(discussion.createdAt)}
+                      </div>
+                      <div className="flex items-center">
+                        <ChatBubbleLeftRightIcon className="h-4 w-4 mr-1" />
+                        {discussion.comments.totalCount} comments
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </CardBody>
+            </Card>
+          ))}
+          
+          <div className="flex justify-center mt-6">
+            <Pagination
+              total={Math.ceil(totalCount / itemsPerPage)}
+              page={page}
+              onChange={setPage}
+              showControls
+            />
+          </div>
+        </div>
+      ) : (
+        <Card>
+          <CardBody className="py-8">
+            <div className="text-center">
+              <ChatBubbleLeftRightIcon className="h-16 w-16 mx-auto text-gray-400 dark:text-gray-600 mb-4" />
+              <h3 className="text-lg font-medium text-gray-900 dark:text-gray-100 mb-2">No discussions found</h3>
+              <p className="text-gray-500 dark:text-gray-400 mb-6">
+                {searchQuery || selectedCategory !== "all"
+                  ? "No discussions match your filters. Try adjusting your search criteria."
+                  : "This repository doesn't have any discussions yet. Start the conversation!"}
+              </p>
+              <Button
+                color="primary"
+                onPress={onCreateDiscussion}
+              >
+                Start a new discussion
+              </Button>
+            </div>
+          </CardBody>
+        </Card>
+      )}
+    </div>
+  );
+}

--- a/app/repositories/[owner]/[repo]/discussions/[number]/page.tsx
+++ b/app/repositories/[owner]/[repo]/discussions/[number]/page.tsx
@@ -1,0 +1,111 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { useParams } from "next/navigation";
+import Link from "next/link";
+import { useGitHub } from "../../../../../context/GitHubContext";
+import MainLayout from "../../../../../components/layout/MainLayout";
+import DiscussionDetail from "../../../../../components/discussions/DiscussionDetail";
+import {
+  Card,
+  CardBody,
+  CardHeader,
+  Button,
+  Spinner
+} from "@nextui-org/react";
+import { ArrowLeftIcon } from "@heroicons/react/24/outline";
+
+export default function DiscussionDetailPage() {
+  const params = useParams();
+  const owner = params.owner as string;
+  const repo = params.repo as string;
+  const discussionNumber = parseInt(params.number as string, 10);
+
+  const { githubService } = useGitHub();
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    // Just to check if the repository exists
+    async function checkRepository() {
+      if (!githubService) return;
+      
+      try {
+        setIsLoading(true);
+        setError(null);
+        
+        await githubService.getRepository(owner, repo);
+      } catch (err) {
+        console.error("Error fetching repository:", err);
+        setError("Repository not found or you don't have access to it.");
+      } finally {
+        setIsLoading(false);
+      }
+    }
+    
+    checkRepository();
+  }, [githubService, owner, repo]);
+
+  if (isLoading) {
+    return (
+      <MainLayout>
+        <div className="container mx-auto py-6">
+          <div className="flex justify-center items-center h-64">
+            <Spinner size="lg" />
+          </div>
+        </div>
+      </MainLayout>
+    );
+  }
+
+  if (error) {
+    return (
+      <MainLayout>
+        <div className="container mx-auto py-6">
+          <div className="bg-red-100 dark:bg-red-900 text-red-800 dark:text-red-200 p-4 rounded-md">
+            {error}
+          </div>
+          <div className="mt-4">
+            <Link href={`/repositories/${owner}/${repo}/discussions`} className="text-blue-600 dark:text-blue-400 hover:underline">
+              ← Back to Discussions
+            </Link>
+          </div>
+        </div>
+      </MainLayout>
+    );
+  }
+
+  return (
+    <MainLayout>
+      <div className="container mx-auto py-6">
+        <div className="mb-6">
+          <div className="flex items-center space-x-2 text-sm text-gray-600 dark:text-gray-400 mb-2">
+            <Link href="/repositories" className="hover:text-blue-600 dark:hover:text-blue-400">
+              Repositories
+            </Link>
+            <span>/</span>
+            <Link href={`/repositories/${owner}/${repo}`} className="hover:text-blue-600 dark:hover:text-blue-400">
+              {owner}/{repo}
+            </Link>
+            <span>/</span>
+            <Link href={`/repositories/${owner}/${repo}/discussions`} className="hover:text-blue-600 dark:hover:text-blue-400">
+              Discussions
+            </Link>
+            <span>/</span>
+            <span className="text-gray-900 dark:text-gray-200">#{discussionNumber}</span>
+          </div>
+        </div>
+
+        <Card>
+          <CardBody>
+            <DiscussionDetail
+              owner={owner}
+              repo={repo}
+              discussionNumber={discussionNumber}
+            />
+          </CardBody>
+        </Card>
+      </div>
+    </MainLayout>
+  );
+}

--- a/app/repositories/[owner]/[repo]/discussions/page.tsx
+++ b/app/repositories/[owner]/[repo]/discussions/page.tsx
@@ -1,0 +1,136 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { useParams, useRouter } from "next/navigation";
+import Link from "next/link";
+import { useGitHub } from "../../../../context/GitHubContext";
+import MainLayout from "../../../../components/layout/MainLayout";
+import DiscussionList from "../../../../components/discussions/DiscussionList";
+import CreateDiscussionModal from "../../../../components/discussions/CreateDiscussionModal";
+import {
+  Card,
+  CardBody,
+  CardHeader,
+  Button,
+  Spinner
+} from "@nextui-org/react";
+import { ArrowLeftIcon } from "@heroicons/react/24/outline";
+
+export default function DiscussionsPage() {
+  const params = useParams();
+  const router = useRouter();
+  const owner = params.owner as string;
+  const repo = params.repo as string;
+
+  const { githubService } = useGitHub();
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [showCreateModal, setShowCreateModal] = useState(false);
+
+  useEffect(() => {
+    // Just to check if the repository exists
+    async function checkRepository() {
+      if (!githubService) return;
+      
+      try {
+        setIsLoading(true);
+        setError(null);
+        
+        await githubService.getRepository(owner, repo);
+      } catch (err) {
+        console.error("Error fetching repository:", err);
+        setError("Repository not found or you don't have access to it.");
+      } finally {
+        setIsLoading(false);
+      }
+    }
+    
+    checkRepository();
+  }, [githubService, owner, repo]);
+
+  // Handle discussion created
+  const handleDiscussionCreated = (discussionNumber: number) => {
+    // Navigate to the newly created discussion
+    router.push(`/repositories/${owner}/${repo}/discussions/${discussionNumber}`);
+  };
+
+  if (isLoading) {
+    return (
+      <MainLayout>
+        <div className="container mx-auto py-6">
+          <div className="flex justify-center items-center h-64">
+            <Spinner size="lg" />
+          </div>
+        </div>
+      </MainLayout>
+    );
+  }
+
+  if (error) {
+    return (
+      <MainLayout>
+        <div className="container mx-auto py-6">
+          <div className="bg-red-100 dark:bg-red-900 text-red-800 dark:text-red-200 p-4 rounded-md">
+            {error}
+          </div>
+          <div className="mt-4">
+            <Link href="/repositories" className="text-blue-600 dark:text-blue-400 hover:underline">
+              ← Back to Repositories
+            </Link>
+          </div>
+        </div>
+      </MainLayout>
+    );
+  }
+
+  return (
+    <MainLayout>
+      <div className="container mx-auto py-6">
+        <div className="mb-6">
+          <div className="flex items-center space-x-2 text-sm text-gray-600 dark:text-gray-400 mb-2">
+            <Link href="/repositories" className="hover:text-blue-600 dark:hover:text-blue-400">
+              Repositories
+            </Link>
+            <span>/</span>
+            <Link href={`/repositories/${owner}/${repo}`} className="hover:text-blue-600 dark:hover:text-blue-400">
+              {owner}/{repo}
+            </Link>
+            <span>/</span>
+            <span className="text-gray-900 dark:text-gray-200">Discussions</span>
+          </div>
+
+          <div className="flex justify-between items-center">
+            <h1 className="text-2xl font-bold">Discussions</h1>
+            <Button
+              as="a"
+              href={`https://github.com/${owner}/${repo}/discussions`}
+              target="_blank"
+              rel="noopener noreferrer"
+              variant="flat"
+            >
+              View on GitHub
+            </Button>
+          </div>
+        </div>
+
+        <Card>
+          <CardBody>
+            <DiscussionList
+              owner={owner}
+              repo={repo}
+              onCreateDiscussion={() => setShowCreateModal(true)}
+            />
+          </CardBody>
+        </Card>
+
+        <CreateDiscussionModal
+          isOpen={showCreateModal}
+          onClose={() => setShowCreateModal(false)}
+          owner={owner}
+          repo={repo}
+          onDiscussionCreated={handleDiscussionCreated}
+        />
+      </div>
+    </MainLayout>
+  );
+}

--- a/app/repositories/[owner]/[repo]/page.tsx
+++ b/app/repositories/[owner]/[repo]/page.tsx
@@ -31,7 +31,7 @@ export default function RepositoryDetailPage({ params }: RepositoryDetailPagePro
   const [repository, setRepository] = useState<GitHubRepository | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-  const [activeTab, setActiveTab] = useState<"code" | "issues" | "pull-requests" | "actions" | "insights" | "analytics">("code");
+  const [activeTab, setActiveTab] = useState<"code" | "issues" | "pull-requests" | "discussions" | "actions" | "insights" | "analytics">("code");
 
   useEffect(() => {
     if (!authLoading && !isAuthenticated) {
@@ -198,6 +198,19 @@ export default function RepositoryDetailPage({ params }: RepositoryDetailPagePro
                 </button>
                 <button
                   className={`py-4 px-6 border-b-2 font-medium text-sm ${
+                    activeTab === 'discussions'
+                      ? 'border-blue-500 text-blue-600 dark:text-blue-400'
+                      : 'border-transparent text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-300'
+                  }`}
+                  onClick={() => setActiveTab('discussions')}
+                >
+                  <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5 inline mr-1" viewBox="0 0 20 20" fill="currentColor">
+                    <path fillRule="evenodd" d="M18 5v8a2 2 0 01-2 2h-5l-5 4v-4H4a2 2 0 01-2-2V5a2 2 0 012-2h12a2 2 0 012 2zM7 8H5v2h2V8zm2 0h2v2H9V8zm6 0h-2v2h2V8z" clipRule="evenodd" />
+                  </svg>
+                  Discussions
+                </button>
+                <button
+                  className={`py-4 px-6 border-b-2 font-medium text-sm ${
                     activeTab === 'actions'
                       ? 'border-blue-500 text-blue-600 dark:text-blue-400'
                       : 'border-transparent text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-300'
@@ -324,6 +337,38 @@ export default function RepositoryDetailPage({ params }: RepositoryDetailPagePro
                       <p className="text-gray-600 dark:text-gray-400 mb-4">
                         Pull requests list is being loaded from the Pull Requests page. Click "View All Pull Requests" to see them.
                       </p>
+                    </div>
+                  </div>
+                </div>
+              )}
+
+              {activeTab === 'discussions' && (
+                <div className="space-y-6">
+                  <div className="flex justify-between items-center">
+                    <h3 className="text-xl font-medium">Discussions</h3>
+                    <Link
+                      href={`/repositories/${ownerName}/${repoName}/discussions`}
+                      className="inline-flex items-center text-sm text-blue-600 dark:text-blue-400 hover:underline"
+                    >
+                      View All Discussions
+                    </Link>
+                  </div>
+
+                  <div className="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-6">
+                    <div className="text-center py-8">
+                      <svg xmlns="http://www.w3.org/2000/svg" className="h-16 w-16 mx-auto text-gray-400 dark:text-gray-600 mb-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1} d="M8 10h.01M12 10h.01M16 10h.01M9 16H5a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v8a2 2 0 01-2 2h-5l-5 5v-5z" />
+                      </svg>
+                      <h3 className="text-lg font-medium text-gray-900 dark:text-gray-100 mb-2">GitHub Discussions</h3>
+                      <p className="text-gray-500 dark:text-gray-400 mb-6">
+                        Collaborate with your community using GitHub Discussions.
+                      </p>
+                      <Link
+                        href={`/repositories/${ownerName}/${repoName}/discussions`}
+                        className="bg-blue-600 hover:bg-blue-700 text-white py-2 px-4 rounded-md text-sm"
+                      >
+                        View Discussions
+                      </Link>
                     </div>
                   </div>
                 </div>

--- a/app/services/github/queries/discussionsQueries.ts
+++ b/app/services/github/queries/discussionsQueries.ts
@@ -1,0 +1,282 @@
+/**
+ * GraphQL queries for GitHub Discussions
+ */
+
+// Query to get repository discussions
+export const GET_REPOSITORY_DISCUSSIONS = `
+  query GetRepositoryDiscussions($owner: String!, $name: String!, $first: Int!, $after: String) {
+    repository(owner: $owner, name: $name) {
+      discussions(first: $first, after: $after) {
+        pageInfo {
+          hasNextPage
+          endCursor
+        }
+        totalCount
+        nodes {
+          id
+          number
+          title
+          body
+          createdAt
+          updatedAt
+          url
+          author {
+            login
+            avatarUrl
+          }
+          category {
+            id
+            name
+            emoji
+            description
+          }
+          comments(first: 0) {
+            totalCount
+          }
+          labels(first: 10) {
+            nodes {
+              id
+              name
+              color
+            }
+          }
+          answerChosenAt
+          answerChosenBy {
+            login
+            avatarUrl
+          }
+        }
+      }
+    }
+  }
+`;
+
+// Query to get a single discussion
+export const GET_DISCUSSION = `
+  query GetDiscussion($owner: String!, $name: String!, $number: Int!) {
+    repository(owner: $owner, name: $name) {
+      discussion(number: $number) {
+        id
+        number
+        title
+        body
+        bodyHTML
+        createdAt
+        updatedAt
+        url
+        author {
+          login
+          avatarUrl
+        }
+        category {
+          id
+          name
+          emoji
+          description
+        }
+        labels(first: 10) {
+          nodes {
+            id
+            name
+            color
+          }
+        }
+        answerChosenAt
+        answerChosenBy {
+          login
+          avatarUrl
+        }
+      }
+    }
+  }
+`;
+
+// Query to get discussion comments
+export const GET_DISCUSSION_COMMENTS = `
+  query GetDiscussionComments($owner: String!, $name: String!, $number: Int!, $first: Int!, $after: String) {
+    repository(owner: $owner, name: $name) {
+      discussion(number: $number) {
+        comments(first: $first, after: $after) {
+          pageInfo {
+            hasNextPage
+            endCursor
+          }
+          totalCount
+          nodes {
+            id
+            body
+            bodyHTML
+            createdAt
+            updatedAt
+            author {
+              login
+              avatarUrl
+            }
+            isAnswer
+            reactionGroups {
+              content
+              users {
+                totalCount
+              }
+            }
+            replies(first: 3) {
+              totalCount
+              nodes {
+                id
+                body
+                author {
+                  login
+                  avatarUrl
+                }
+                createdAt
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+`;
+
+// Query to get discussion categories
+export const GET_DISCUSSION_CATEGORIES = `
+  query GetDiscussionCategories($owner: String!, $name: String!) {
+    repository(owner: $owner, name: $name) {
+      discussionCategories(first: 20) {
+        nodes {
+          id
+          name
+          emoji
+          description
+          isAnswerable
+        }
+      }
+    }
+  }
+`;
+
+// Mutation to create a discussion
+export const CREATE_DISCUSSION = `
+  mutation CreateDiscussion($input: CreateDiscussionInput!) {
+    createDiscussion(input: $input) {
+      discussion {
+        id
+        number
+        url
+      }
+    }
+  }
+`;
+
+// Mutation to add a discussion comment
+export const ADD_DISCUSSION_COMMENT = `
+  mutation AddDiscussionComment($input: AddDiscussionCommentInput!) {
+    addDiscussionComment(input: $input) {
+      comment {
+        id
+        body
+        createdAt
+        author {
+          login
+          avatarUrl
+        }
+      }
+    }
+  }
+`;
+
+// Mutation to add a discussion reply
+export const ADD_DISCUSSION_REPLY = `
+  mutation AddDiscussionReply($input: AddDiscussionReplyInput!) {
+    addDiscussionReply(input: $input) {
+      reply {
+        id
+        body
+        createdAt
+        author {
+          login
+          avatarUrl
+        }
+      }
+    }
+  }
+`;
+
+// Mutation to mark a comment as an answer
+export const MARK_DISCUSSION_COMMENT_AS_ANSWER = `
+  mutation MarkDiscussionCommentAsAnswer($input: MarkDiscussionCommentAsAnswerInput!) {
+    markDiscussionCommentAsAnswer(input: $input) {
+      discussion {
+        id
+        answerChosenAt
+        answerChosenBy {
+          login
+        }
+      }
+    }
+  }
+`;
+
+// Mutation to unmark a comment as an answer
+export const UNMARK_DISCUSSION_COMMENT_AS_ANSWER = `
+  mutation UnmarkDiscussionCommentAsAnswer($input: UnmarkDiscussionCommentAsAnswerInput!) {
+    unmarkDiscussionCommentAsAnswer(input: $input) {
+      discussion {
+        id
+        answerChosenAt
+        answerChosenBy {
+          login
+        }
+      }
+    }
+  }
+`;
+
+// Mutation to add a reaction to a discussion comment
+export const ADD_REACTION = `
+  mutation AddReaction($input: AddReactionInput!) {
+    addReaction(input: $input) {
+      reaction {
+        content
+      }
+    }
+  }
+`;
+
+// Mutation to remove a reaction from a discussion comment
+export const REMOVE_REACTION = `
+  mutation RemoveReaction($input: RemoveReactionInput!) {
+    removeReaction(input: $input) {
+      reaction {
+        content
+      }
+    }
+  }
+`;
+
+// Query to get trending discussions
+export const GET_TRENDING_DISCUSSIONS = `
+  query GetTrendingDiscussions($owner: String!, $name: String!, $since: DateTime!) {
+    repository(owner: $owner, name: $name) {
+      discussions(first: 10, orderBy: {field: CREATED_AT, direction: DESC}) {
+        nodes {
+          id
+          number
+          title
+          createdAt
+          author {
+            login
+            avatarUrl
+          }
+          comments(first: 0) {
+            totalCount
+          }
+          category {
+            name
+            emoji
+          }
+        }
+      }
+    }
+  }
+`;


### PR DESCRIPTION
This PR adds support for GitHub Discussions using the GraphQL API.

## Features
- Added GraphQL queries for GitHub Discussions
- Extended GitHubService with methods for GitHub Discussions
- Created components for displaying discussions, discussion details, and creating new discussions
- Added pages for viewing discussions and discussion details
- Updated the repository page to include a tab for GitHub Discussions

## Testing
- Tested with GitHub repository discussions
- Verified discussion details display correctly
- Tested creating new discussions and adding comments