### PR TITLE
Add settings page

### DIFF
--- a/app/components/settings/AppearanceSettings.tsx
+++ b/app/components/settings/AppearanceSettings.tsx
@@ -1,0 +1,173 @@
+"use client";
+
+import { FC, useState, useEffect } from 'react';
+import { useTheme } from '../../context/ThemeContext';
+import { Radio, RadioGroup, Card, CardBody, Button, Divider, Switch } from '@nextui-org/react';
+
+const AppearanceSettings: FC = () => {
+  const { theme, setTheme } = useTheme();
+  const [fontSize, setFontSize] = useState('medium');
+  const [reducedMotion, setReducedMotion] = useState(false);
+  const [highContrast, setHighContrast] = useState(false);
+  const [codeTheme, setCodeTheme] = useState('github');
+
+  // Load saved preferences from localStorage
+  useEffect(() => {
+    if (typeof window !== 'undefined') {
+      const savedFontSize = localStorage.getItem('github-nexus-font-size');
+      const savedReducedMotion = localStorage.getItem('github-nexus-reduced-motion');
+      const savedHighContrast = localStorage.getItem('github-nexus-high-contrast');
+      const savedCodeTheme = localStorage.getItem('github-nexus-code-theme');
+
+      if (savedFontSize) setFontSize(savedFontSize);
+      if (savedReducedMotion) setReducedMotion(savedReducedMotion === 'true');
+      if (savedHighContrast) setHighContrast(savedHighContrast === 'true');
+      if (savedCodeTheme) setCodeTheme(savedCodeTheme);
+    }
+  }, []);
+
+  // Save preferences to localStorage when they change
+  useEffect(() => {
+    localStorage.setItem('github-nexus-font-size', fontSize);
+    localStorage.setItem('github-nexus-reduced-motion', String(reducedMotion));
+    localStorage.setItem('github-nexus-high-contrast', String(highContrast));
+    localStorage.setItem('github-nexus-code-theme', codeTheme);
+
+    // Apply font size to document
+    document.documentElement.style.fontSize = 
+      fontSize === 'small' ? '14px' : 
+      fontSize === 'medium' ? '16px' : '18px';
+
+    // Apply reduced motion
+    if (reducedMotion) {
+      document.documentElement.classList.add('reduce-motion');
+    } else {
+      document.documentElement.classList.remove('reduce-motion');
+    }
+
+    // Apply high contrast
+    if (highContrast) {
+      document.documentElement.classList.add('high-contrast');
+    } else {
+      document.documentElement.classList.remove('high-contrast');
+    }
+  }, [fontSize, reducedMotion, highContrast, codeTheme]);
+
+  const handleThemeChange = (value: string) => {
+    setTheme(value as 'light' | 'dark');
+  };
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h2 className="text-xl font-semibold mb-4">Appearance Settings</h2>
+        <p className="text-gray-600 dark:text-gray-400 mb-6">
+          Customize how GitHub Nexus looks and feels
+        </p>
+      </div>
+
+      <div className="space-y-8">
+        <div>
+          <h3 className="text-lg font-medium mb-4">Theme</h3>
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+            <Card 
+              isPressable 
+              isHoverable
+              className={`border-2 ${theme === 'light' ? 'border-blue-500' : 'border-transparent'}`}
+              onPress={() => handleThemeChange('light')}
+            >
+              <CardBody className="p-4">
+                <div className="bg-white border border-gray-200 rounded-md p-3 mb-3">
+                  <div className="h-2 w-24 bg-gray-300 rounded mb-2"></div>
+                  <div className="h-2 w-16 bg-gray-300 rounded"></div>
+                </div>
+                <p className="text-center font-medium">Light</p>
+              </CardBody>
+            </Card>
+
+            <Card 
+              isPressable 
+              isHoverable
+              className={`border-2 ${theme === 'dark' ? 'border-blue-500' : 'border-transparent'}`}
+              onPress={() => handleThemeChange('dark')}
+            >
+              <CardBody className="p-4">
+                <div className="bg-gray-900 border border-gray-700 rounded-md p-3 mb-3">
+                  <div className="h-2 w-24 bg-gray-700 rounded mb-2"></div>
+                  <div className="h-2 w-16 bg-gray-700 rounded"></div>
+                </div>
+                <p className="text-center font-medium">Dark</p>
+              </CardBody>
+            </Card>
+          </div>
+        </div>
+
+        <Divider />
+
+        <div>
+          <h3 className="text-lg font-medium mb-4">Text Size</h3>
+          <RadioGroup
+            value={fontSize}
+            onValueChange={setFontSize}
+            orientation="horizontal"
+          >
+            <Radio value="small">Small</Radio>
+            <Radio value="medium">Medium</Radio>
+            <Radio value="large">Large</Radio>
+          </RadioGroup>
+        </div>
+
+        <Divider />
+
+        <div>
+          <h3 className="text-lg font-medium mb-4">Code Theme</h3>
+          <RadioGroup
+            value={codeTheme}
+            onValueChange={setCodeTheme}
+            orientation="horizontal"
+          >
+            <Radio value="github">GitHub</Radio>
+            <Radio value="vscode">VS Code</Radio>
+            <Radio value="monokai">Monokai</Radio>
+            <Radio value="dracula">Dracula</Radio>
+          </RadioGroup>
+        </div>
+
+        <Divider />
+
+        <div>
+          <h3 className="text-lg font-medium mb-4">Accessibility</h3>
+          <div className="space-y-4">
+            <div className="flex justify-between items-center">
+              <div>
+                <p className="font-medium">Reduced Motion</p>
+                <p className="text-sm text-gray-600 dark:text-gray-400">
+                  Minimize animations throughout the interface
+                </p>
+              </div>
+              <Switch
+                isSelected={reducedMotion}
+                onValueChange={setReducedMotion}
+              />
+            </div>
+
+            <div className="flex justify-between items-center">
+              <div>
+                <p className="font-medium">High Contrast</p>
+                <p className="text-sm text-gray-600 dark:text-gray-400">
+                  Increase contrast for better readability
+                </p>
+              </div>
+              <Switch
+                isSelected={highContrast}
+                onValueChange={setHighContrast}
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default AppearanceSettings;

--- a/app/components/settings/IntegrationSettings.tsx
+++ b/app/components/settings/IntegrationSettings.tsx
@@ -1,0 +1,221 @@
+"use client";
+
+import { FC, useState, useEffect } from 'react';
+import { Card, CardBody, Button, Switch, Divider, Input } from '@nextui-org/react';
+import { useAuth } from '../../hooks/useAuth';
+
+interface Integration {
+  id: string;
+  name: string;
+  description: string;
+  connected: boolean;
+  icon: string;
+}
+
+const IntegrationSettings: FC = () => {
+  const { session } = useAuth();
+  const [integrations, setIntegrations] = useState<Integration[]>([
+    {
+      id: 'slack',
+      name: 'Slack',
+      description: 'Receive notifications and updates in your Slack workspace',
+      connected: false,
+      icon: '/icons/slack.svg'
+    },
+    {
+      id: 'discord',
+      name: 'Discord',
+      description: 'Connect your Discord server for notifications and updates',
+      connected: false,
+      icon: '/icons/discord.svg'
+    },
+    {
+      id: 'jira',
+      name: 'Jira',
+      description: 'Link GitHub issues and pull requests with Jira tickets',
+      connected: false,
+      icon: '/icons/jira.svg'
+    },
+    {
+      id: 'vscode',
+      name: 'VS Code',
+      description: 'Integrate with VS Code for a seamless development experience',
+      connected: false,
+      icon: '/icons/vscode.svg'
+    },
+    {
+      id: 'jenkins',
+      name: 'Jenkins',
+      description: 'Connect your Jenkins CI/CD pipelines',
+      connected: false,
+      icon: '/icons/jenkins.svg'
+    }
+  ]);
+  const [webhookUrl, setWebhookUrl] = useState('');
+
+  // Load saved integrations from localStorage
+  useEffect(() => {
+    if (typeof window !== 'undefined') {
+      const savedIntegrations = localStorage.getItem('github-nexus-integrations');
+      const savedWebhookUrl = localStorage.getItem('github-nexus-webhook-url');
+      
+      if (savedIntegrations) {
+        try {
+          setIntegrations(JSON.parse(savedIntegrations));
+        } catch (error) {
+          console.error('Error parsing integrations:', error);
+        }
+      }
+      
+      if (savedWebhookUrl) {
+        setWebhookUrl(savedWebhookUrl);
+      }
+    }
+  }, []);
+
+  // Save integrations to localStorage when they change
+  useEffect(() => {
+    localStorage.setItem('github-nexus-integrations', JSON.stringify(integrations));
+  }, [integrations]);
+
+  // Save webhook URL to localStorage when it changes
+  useEffect(() => {
+    localStorage.setItem('github-nexus-webhook-url', webhookUrl);
+  }, [webhookUrl]);
+
+  const toggleIntegration = (id: string) => {
+    setIntegrations(prev => 
+      prev.map(integration => 
+        integration.id === id 
+          ? { ...integration, connected: !integration.connected } 
+          : integration
+      )
+    );
+  };
+
+  const handleWebhookUrlChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setWebhookUrl(e.target.value);
+  };
+
+  const saveWebhookUrl = () => {
+    // Save webhook URL (already saved in useEffect)
+    alert('Webhook URL saved successfully');
+  };
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h2 className="text-xl font-semibold mb-4">Integration Settings</h2>
+        <p className="text-gray-600 dark:text-gray-400 mb-6">
+          Connect GitHub Nexus with other tools and services
+        </p>
+      </div>
+
+      <div className="space-y-6">
+        <div>
+          <h3 className="text-lg font-medium mb-4">Connected Services</h3>
+          <div className="space-y-4">
+            {integrations.map(integration => (
+              <Card key={integration.id} className="border border-gray-200 dark:border-gray-800">
+                <CardBody className="flex flex-row items-center justify-between p-4">
+                  <div className="flex items-center space-x-4">
+                    <div className="w-10 h-10 flex items-center justify-center bg-gray-100 dark:bg-gray-800 rounded-md">
+                      {/* Placeholder for icon */}
+                      <svg xmlns="http://www.w3.org/2000/svg" className="h-6 w-6 text-gray-600 dark:text-gray-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 10V3L4 14h7v7l9-11h-7z" />
+                      </svg>
+                    </div>
+                    <div>
+                      <h4 className="font-medium">{integration.name}</h4>
+                      <p className="text-sm text-gray-600 dark:text-gray-400">
+                        {integration.description}
+                      </p>
+                    </div>
+                  </div>
+                  <div className="flex items-center space-x-4">
+                    <span className={`text-sm ${integration.connected ? 'text-green-600 dark:text-green-400' : 'text-gray-500 dark:text-gray-400'}`}>
+                      {integration.connected ? 'Connected' : 'Not connected'}
+                    </span>
+                    <Switch
+                      isSelected={integration.connected}
+                      onValueChange={() => toggleIntegration(integration.id)}
+                    />
+                  </div>
+                </CardBody>
+              </Card>
+            ))}
+          </div>
+        </div>
+
+        <Divider />
+
+        <div>
+          <h3 className="text-lg font-medium mb-4">Webhook Configuration</h3>
+          <p className="text-sm text-gray-600 dark:text-gray-400 mb-4">
+            Configure a webhook URL to receive events from GitHub Nexus
+          </p>
+          
+          <div className="space-y-4">
+            <Input
+              label="Webhook URL"
+              placeholder="https://example.com/webhook"
+              value={webhookUrl}
+              onChange={handleWebhookUrlChange}
+              variant="bordered"
+              fullWidth
+            />
+            
+            <Button
+              color="primary"
+              onClick={saveWebhookUrl}
+            >
+              Save Webhook
+            </Button>
+          </div>
+        </div>
+
+        <Divider />
+
+        <div>
+          <h3 className="text-lg font-medium mb-4">API Access</h3>
+          <p className="text-sm text-gray-600 dark:text-gray-400 mb-4">
+            Manage API tokens and access for external applications
+          </p>
+          
+          <div className="space-y-4">
+            <Card className="border border-gray-200 dark:border-gray-800">
+              <CardBody className="p-4">
+                <div className="flex justify-between items-center">
+                  <div>
+                    <h4 className="font-medium">GitHub Access Token</h4>
+                    <p className="text-sm text-gray-600 dark:text-gray-400">
+                      {session?.accessToken 
+                        ? 'Token is active and configured' 
+                        : 'No token configured'}
+                    </p>
+                  </div>
+                  <Button
+                    color="primary"
+                    variant="flat"
+                    size="sm"
+                  >
+                    Manage
+                  </Button>
+                </div>
+              </CardBody>
+            </Card>
+            
+            <Button
+              variant="bordered"
+              fullWidth
+            >
+              Generate New API Token
+            </Button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default IntegrationSettings;

--- a/app/components/settings/NotificationSettings.tsx
+++ b/app/components/settings/NotificationSettings.tsx
@@ -1,0 +1,213 @@
+"use client";
+
+import { FC, useState, useEffect } from 'react';
+import { Switch, Divider, Button, Checkbox, CheckboxGroup } from '@nextui-org/react';
+
+interface NotificationPreferences {
+  emailNotifications: boolean;
+  pushNotifications: boolean;
+  notifyOn: string[];
+  digestFrequency: string;
+}
+
+const DEFAULT_PREFERENCES: NotificationPreferences = {
+  emailNotifications: true,
+  pushNotifications: false,
+  notifyOn: ['mentions', 'issues', 'pullRequests', 'releases'],
+  digestFrequency: 'daily',
+};
+
+const NotificationSettings: FC = () => {
+  const [preferences, setPreferences] = useState<NotificationPreferences>(DEFAULT_PREFERENCES);
+  const [isSaving, setIsSaving] = useState(false);
+
+  // Load saved preferences from localStorage
+  useEffect(() => {
+    if (typeof window !== 'undefined') {
+      const savedPreferences = localStorage.getItem('github-nexus-notification-preferences');
+      if (savedPreferences) {
+        try {
+          setPreferences(JSON.parse(savedPreferences));
+        } catch (error) {
+          console.error('Error parsing notification preferences:', error);
+        }
+      }
+    }
+  }, []);
+
+  const handleSwitchChange = (key: keyof NotificationPreferences) => (checked: boolean) => {
+    setPreferences(prev => ({
+      ...prev,
+      [key]: checked
+    }));
+  };
+
+  const handleNotifyOnChange = (values: string[]) => {
+    setPreferences(prev => ({
+      ...prev,
+      notifyOn: values
+    }));
+  };
+
+  const handleDigestFrequencyChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setPreferences(prev => ({
+      ...prev,
+      digestFrequency: e.target.value
+    }));
+  };
+
+  const handleSave = () => {
+    setIsSaving(true);
+    
+    // Save to localStorage
+    localStorage.setItem('github-nexus-notification-preferences', JSON.stringify(preferences));
+    
+    // Simulate API call
+    setTimeout(() => {
+      setIsSaving(false);
+      alert('Notification preferences saved successfully');
+    }, 1000);
+  };
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h2 className="text-xl font-semibold mb-4">Notification Settings</h2>
+        <p className="text-gray-600 dark:text-gray-400 mb-6">
+          Manage how and when you receive notifications from GitHub Nexus
+        </p>
+      </div>
+
+      <div className="space-y-6">
+        <div>
+          <h3 className="text-lg font-medium mb-4">Notification Channels</h3>
+          <div className="space-y-4">
+            <div className="flex justify-between items-center">
+              <div>
+                <p className="font-medium">Email Notifications</p>
+                <p className="text-sm text-gray-600 dark:text-gray-400">
+                  Receive notifications via email
+                </p>
+              </div>
+              <Switch
+                isSelected={preferences.emailNotifications}
+                onValueChange={handleSwitchChange('emailNotifications')}
+              />
+            </div>
+
+            <div className="flex justify-between items-center">
+              <div>
+                <p className="font-medium">Push Notifications</p>
+                <p className="text-sm text-gray-600 dark:text-gray-400">
+                  Receive browser push notifications
+                </p>
+              </div>
+              <Switch
+                isSelected={preferences.pushNotifications}
+                onValueChange={handleSwitchChange('pushNotifications')}
+              />
+            </div>
+          </div>
+        </div>
+
+        <Divider />
+
+        <div>
+          <h3 className="text-lg font-medium mb-4">Notification Types</h3>
+          <p className="text-sm text-gray-600 dark:text-gray-400 mb-4">
+            Select which events should trigger notifications
+          </p>
+          
+          <CheckboxGroup
+            value={preferences.notifyOn}
+            onValueChange={handleNotifyOnChange}
+            className="gap-1"
+          >
+            <Checkbox value="mentions">@Mentions</Checkbox>
+            <Checkbox value="issues">Issues</Checkbox>
+            <Checkbox value="pullRequests">Pull Requests</Checkbox>
+            <Checkbox value="reviews">Code Reviews</Checkbox>
+            <Checkbox value="releases">Releases</Checkbox>
+            <Checkbox value="discussions">Discussions</Checkbox>
+            <Checkbox value="securityAlerts">Security Alerts</Checkbox>
+          </CheckboxGroup>
+        </div>
+
+        <Divider />
+
+        <div>
+          <h3 className="text-lg font-medium mb-4">Digest Frequency</h3>
+          <p className="text-sm text-gray-600 dark:text-gray-400 mb-4">
+            How often would you like to receive notification digests?
+          </p>
+          
+          <div className="space-y-2">
+            <div className="flex items-center">
+              <input
+                type="radio"
+                id="realtime"
+                name="digestFrequency"
+                value="realtime"
+                checked={preferences.digestFrequency === 'realtime'}
+                onChange={handleDigestFrequencyChange}
+                className="mr-2"
+              />
+              <label htmlFor="realtime">Real-time (as they happen)</label>
+            </div>
+            
+            <div className="flex items-center">
+              <input
+                type="radio"
+                id="hourly"
+                name="digestFrequency"
+                value="hourly"
+                checked={preferences.digestFrequency === 'hourly'}
+                onChange={handleDigestFrequencyChange}
+                className="mr-2"
+              />
+              <label htmlFor="hourly">Hourly digest</label>
+            </div>
+            
+            <div className="flex items-center">
+              <input
+                type="radio"
+                id="daily"
+                name="digestFrequency"
+                value="daily"
+                checked={preferences.digestFrequency === 'daily'}
+                onChange={handleDigestFrequencyChange}
+                className="mr-2"
+              />
+              <label htmlFor="daily">Daily digest</label>
+            </div>
+            
+            <div className="flex items-center">
+              <input
+                type="radio"
+                id="weekly"
+                name="digestFrequency"
+                value="weekly"
+                checked={preferences.digestFrequency === 'weekly'}
+                onChange={handleDigestFrequencyChange}
+                className="mr-2"
+              />
+              <label htmlFor="weekly">Weekly digest</label>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div className="flex justify-end mt-6">
+        <Button
+          color="primary"
+          onClick={handleSave}
+          isLoading={isSaving}
+        >
+          Save Preferences
+        </Button>
+      </div>
+    </div>
+  );
+};
+
+export default NotificationSettings;

--- a/app/components/settings/ProfileSettings.tsx
+++ b/app/components/settings/ProfileSettings.tsx
@@ -1,0 +1,215 @@
+"use client";
+
+import { FC, useState, useEffect } from 'react';
+import { useAuth } from '../../hooks/useAuth';
+import { useGitHub } from '../../context/GitHubContext';
+import { Input, Button, Avatar, Divider } from '@nextui-org/react';
+import Image from 'next/image';
+
+const ProfileSettings: FC = () => {
+  const { session } = useAuth();
+  const { githubService } = useGitHub();
+  const [isLoading, setIsLoading] = useState(false);
+  const [isSaving, setIsSaving] = useState(false);
+  const [userData, setUserData] = useState({
+    name: '',
+    bio: '',
+    company: '',
+    location: '',
+    website: '',
+    twitter: '',
+  });
+
+  useEffect(() => {
+    async function fetchUserProfile() {
+      if (!githubService) return;
+      
+      setIsLoading(true);
+      try {
+        const user = await githubService.getCurrentUser();
+        setUserData({
+          name: user.name || '',
+          bio: user.bio || '',
+          company: user.company || '',
+          location: user.location || '',
+          website: user.blog || '',
+          twitter: user.twitter_username || '',
+        });
+      } catch (error) {
+        console.error('Error fetching user profile:', error);
+      } finally {
+        setIsLoading(false);
+      }
+    }
+
+    fetchUserProfile();
+  }, [githubService]);
+
+  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const { name, value } = e.target;
+    setUserData(prev => ({
+      ...prev,
+      [name]: value
+    }));
+  };
+
+  const handleSave = async () => {
+    if (!githubService) return;
+    
+    setIsSaving(true);
+    try {
+      await githubService.updateUser({
+        name: userData.name,
+        bio: userData.bio,
+        company: userData.company,
+        location: userData.location,
+        blog: userData.website,
+        twitter_username: userData.twitter,
+      });
+      // Show success message
+      alert('Profile updated successfully');
+    } catch (error) {
+      console.error('Error updating profile:', error);
+      alert('Failed to update profile. Please try again.');
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  if (isLoading) {
+    return (
+      <div className="flex justify-center items-center h-64">
+        <div className="animate-spin rounded-full h-8 w-8 border-t-2 border-b-2 border-blue-500"></div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h2 className="text-xl font-semibold mb-4">Profile Settings</h2>
+        <p className="text-gray-600 dark:text-gray-400 mb-6">
+          Manage your GitHub profile information. These changes will be reflected on your GitHub account.
+        </p>
+      </div>
+
+      <div className="flex items-center space-x-4 mb-6">
+        <Avatar
+          src={session?.user?.image || undefined}
+          className="w-20 h-20"
+          alt="Profile"
+        />
+        <div>
+          <p className="font-medium">{session?.user?.name}</p>
+          <p className="text-sm text-gray-600 dark:text-gray-400">{session?.user?.email}</p>
+          <p className="text-xs text-gray-500 dark:text-gray-500 mt-1">
+            Profile picture is managed by GitHub
+          </p>
+        </div>
+      </div>
+
+      <Divider />
+
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+        <div>
+          <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+            Name
+          </label>
+          <Input
+            name="name"
+            value={userData.name}
+            onChange={handleInputChange}
+            placeholder="Your name"
+            variant="bordered"
+            fullWidth
+          />
+        </div>
+
+        <div>
+          <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+            Company
+          </label>
+          <Input
+            name="company"
+            value={userData.company}
+            onChange={handleInputChange}
+            placeholder="Company or organization"
+            variant="bordered"
+            fullWidth
+          />
+        </div>
+
+        <div className="md:col-span-2">
+          <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+            Bio
+          </label>
+          <Input
+            name="bio"
+            value={userData.bio}
+            onChange={handleInputChange}
+            placeholder="Tell us about yourself"
+            variant="bordered"
+            fullWidth
+          />
+        </div>
+
+        <div>
+          <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+            Location
+          </label>
+          <Input
+            name="location"
+            value={userData.location}
+            onChange={handleInputChange}
+            placeholder="Your location"
+            variant="bordered"
+            fullWidth
+          />
+        </div>
+
+        <div>
+          <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+            Website
+          </label>
+          <Input
+            name="website"
+            value={userData.website}
+            onChange={handleInputChange}
+            placeholder="https://example.com"
+            variant="bordered"
+            fullWidth
+          />
+        </div>
+
+        <div>
+          <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+            Twitter Username
+          </label>
+          <Input
+            name="twitter"
+            value={userData.twitter}
+            onChange={handleInputChange}
+            placeholder="@username"
+            variant="bordered"
+            fullWidth
+            startContent={
+              <span className="text-gray-400">@</span>
+            }
+          />
+        </div>
+      </div>
+
+      <div className="flex justify-end mt-6">
+        <Button
+          color="primary"
+          onClick={handleSave}
+          isLoading={isSaving}
+        >
+          Save Changes
+        </Button>
+      </div>
+    </div>
+  );
+};
+
+export default ProfileSettings;

--- a/app/components/settings/SecuritySettings.tsx
+++ b/app/components/settings/SecuritySettings.tsx
@@ -1,0 +1,200 @@
+"use client";
+
+import { FC, useState, useEffect } from 'react';
+import { Card, CardBody, Button, Switch, Divider, Input } from '@nextui-org/react';
+import { useAuth } from '../../hooks/useAuth';
+import Link from 'next/link';
+
+const SecuritySettings: FC = () => {
+  const { session, signOut } = useAuth();
+  const [twoFactorEnabled, setTwoFactorEnabled] = useState(false);
+  const [sessionTimeout, setSessionTimeout] = useState('30');
+  const [showSensitiveData, setShowSensitiveData] = useState(true);
+  const [activityLog, setActivityLog] = useState<string[]>([
+    'Signed in from Chrome on macOS - 2 hours ago',
+    'Changed notification settings - Yesterday',
+    'Connected Slack integration - 3 days ago',
+    'Updated profile information - 1 week ago',
+    'First login - 2 weeks ago'
+  ]);
+
+  // Load saved security settings from localStorage
+  useEffect(() => {
+    if (typeof window !== 'undefined') {
+      const savedTwoFactor = localStorage.getItem('github-nexus-two-factor');
+      const savedSessionTimeout = localStorage.getItem('github-nexus-session-timeout');
+      const savedShowSensitiveData = localStorage.getItem('github-nexus-show-sensitive-data');
+      
+      if (savedTwoFactor) setTwoFactorEnabled(savedTwoFactor === 'true');
+      if (savedSessionTimeout) setSessionTimeout(savedSessionTimeout);
+      if (savedShowSensitiveData) setShowSensitiveData(savedShowSensitiveData === 'true');
+    }
+  }, []);
+
+  // Save security settings to localStorage when they change
+  useEffect(() => {
+    localStorage.setItem('github-nexus-two-factor', String(twoFactorEnabled));
+    localStorage.setItem('github-nexus-session-timeout', sessionTimeout);
+    localStorage.setItem('github-nexus-show-sensitive-data', String(showSensitiveData));
+  }, [twoFactorEnabled, sessionTimeout, showSensitiveData]);
+
+  const handleSessionTimeoutChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    setSessionTimeout(e.target.value);
+  };
+
+  const handleRevokeAllSessions = () => {
+    if (confirm('Are you sure you want to revoke all active sessions? You will be signed out.')) {
+      // In a real app, this would call an API to revoke all sessions
+      alert('All sessions have been revoked. You will now be signed out.');
+      signOut();
+    }
+  };
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h2 className="text-xl font-semibold mb-4">Security Settings</h2>
+        <p className="text-gray-600 dark:text-gray-400 mb-6">
+          Manage your account security and privacy settings
+        </p>
+      </div>
+
+      <div className="space-y-6">
+        <div>
+          <h3 className="text-lg font-medium mb-4">Account Security</h3>
+          
+          <div className="space-y-4">
+            <div className="flex justify-between items-center">
+              <div>
+                <p className="font-medium">Two-Factor Authentication</p>
+                <p className="text-sm text-gray-600 dark:text-gray-400">
+                  Add an extra layer of security to your account
+                </p>
+              </div>
+              <Switch
+                isSelected={twoFactorEnabled}
+                onValueChange={setTwoFactorEnabled}
+              />
+            </div>
+
+            <div>
+              <p className="font-medium mb-2">Session Timeout</p>
+              <p className="text-sm text-gray-600 dark:text-gray-400 mb-3">
+                Automatically sign out after a period of inactivity
+              </p>
+              <select
+                value={sessionTimeout}
+                onChange={handleSessionTimeoutChange}
+                className="block w-full px-3 py-2 bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-700 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500"
+              >
+                <option value="15">15 minutes</option>
+                <option value="30">30 minutes</option>
+                <option value="60">1 hour</option>
+                <option value="120">2 hours</option>
+                <option value="240">4 hours</option>
+                <option value="480">8 hours</option>
+                <option value="never">Never</option>
+              </select>
+            </div>
+
+            <Button
+              color="danger"
+              variant="flat"
+              onClick={handleRevokeAllSessions}
+            >
+              Revoke All Active Sessions
+            </Button>
+          </div>
+        </div>
+
+        <Divider />
+
+        <div>
+          <h3 className="text-lg font-medium mb-4">Privacy</h3>
+          
+          <div className="space-y-4">
+            <div className="flex justify-between items-center">
+              <div>
+                <p className="font-medium">Show Sensitive Data</p>
+                <p className="text-sm text-gray-600 dark:text-gray-400">
+                  Display sensitive repository and organization information
+                </p>
+              </div>
+              <Switch
+                isSelected={showSensitiveData}
+                onValueChange={setShowSensitiveData}
+              />
+            </div>
+
+            <div className="flex justify-between items-center">
+              <div>
+                <p className="font-medium">Activity Tracking</p>
+                <p className="text-sm text-gray-600 dark:text-gray-400">
+                  Allow GitHub Nexus to track your activity for better recommendations
+                </p>
+              </div>
+              <Switch defaultSelected />
+            </div>
+
+            <div className="flex justify-between items-center">
+              <div>
+                <p className="font-medium">Usage Analytics</p>
+                <p className="text-sm text-gray-600 dark:text-gray-400">
+                  Share anonymous usage data to help improve GitHub Nexus
+                </p>
+              </div>
+              <Switch defaultSelected />
+            </div>
+          </div>
+        </div>
+
+        <Divider />
+
+        <div>
+          <h3 className="text-lg font-medium mb-4">Recent Activity</h3>
+          
+          <Card className="border border-gray-200 dark:border-gray-800">
+            <CardBody className="p-0">
+              <ul className="divide-y divide-gray-200 dark:divide-gray-800">
+                {activityLog.map((activity, index) => (
+                  <li key={index} className="px-4 py-3">
+                    <p className="text-sm">{activity}</p>
+                  </li>
+                ))}
+              </ul>
+            </CardBody>
+          </Card>
+          
+          <div className="mt-4">
+            <Link href="/settings/activity" className="text-blue-600 dark:text-blue-400 text-sm">
+              View full activity log →
+            </Link>
+          </div>
+        </div>
+
+        <Divider />
+
+        <div>
+          <h3 className="text-lg font-medium mb-4 text-red-600 dark:text-red-500">Danger Zone</h3>
+          
+          <Card className="border border-red-200 dark:border-red-900 bg-red-50 dark:bg-red-900/20">
+            <CardBody className="p-4">
+              <h4 className="font-medium mb-2">Delete Account</h4>
+              <p className="text-sm text-gray-700 dark:text-gray-300 mb-4">
+                Permanently delete your GitHub Nexus account and all associated data. This action cannot be undone.
+              </p>
+              <Button
+                color="danger"
+                variant="flat"
+              >
+                Delete Account
+              </Button>
+            </CardBody>
+          </Card>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default SecuritySettings;

--- a/app/settings/layout.tsx
+++ b/app/settings/layout.tsx
@@ -1,0 +1,14 @@
+"use client";
+
+import { ReactNode } from "react";
+import MainLayout from "../components/layout/MainLayout";
+
+export default function SettingsLayout({ children }: { children: ReactNode }) {
+  return (
+    <MainLayout>
+      <div className="py-6">
+        {children}
+      </div>
+    </MainLayout>
+  );
+}

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -1,0 +1,149 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { useRouter } from "next/navigation";
+import { useAuth } from "../hooks/useAuth";
+import { Card, CardBody, CardHeader, Divider, Button, Tabs, Tab } from "@nextui-org/react";
+import ProfileSettings from "../components/settings/ProfileSettings";
+import AppearanceSettings from "../components/settings/AppearanceSettings";
+import NotificationSettings from "../components/settings/NotificationSettings";
+import IntegrationSettings from "../components/settings/IntegrationSettings";
+import SecuritySettings from "../components/settings/SecuritySettings";
+
+// Mark this page as dynamically rendered
+export const dynamic = 'force-dynamic';
+export const fetchCache = 'force-no-store';
+
+export default function SettingsPage() {
+  const { isAuthenticated, isLoading } = useAuth();
+  const router = useRouter();
+  const [activeTab, setActiveTab] = useState("profile");
+
+  // Redirect if not authenticated
+  useEffect(() => {
+    if (!isLoading && !isAuthenticated) {
+      router.push('/auth/signin');
+    }
+  }, [isLoading, isAuthenticated, router]);
+
+  if (isLoading) {
+    return (
+      <div className="flex justify-center items-center h-64">
+        <div className="animate-spin rounded-full h-12 w-12 border-t-2 border-b-2 border-blue-500"></div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="max-w-5xl mx-auto">
+      <div className="mb-6">
+        <h1 className="text-3xl font-bold">Settings</h1>
+        <p className="text-gray-600 dark:text-gray-400 mt-2">
+          Manage your GitHub Nexus account settings and preferences
+        </p>
+      </div>
+
+      <div className="flex flex-col md:flex-row gap-6">
+        {/* Settings Navigation */}
+        <div className="w-full md:w-64 flex-shrink-0">
+          <Card className="sticky top-6">
+            <CardBody className="p-0">
+              <nav>
+                <ul className="divide-y divide-gray-200 dark:divide-gray-800">
+                  <li>
+                    <button
+                      onClick={() => setActiveTab("profile")}
+                      className={`w-full text-left px-4 py-3 flex items-center space-x-3 ${
+                        activeTab === "profile"
+                          ? "bg-blue-50 dark:bg-blue-900/20 text-blue-600 dark:text-blue-400"
+                          : "hover:bg-gray-50 dark:hover:bg-gray-800/50"
+                      }`}
+                    >
+                      <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5" viewBox="0 0 20 20" fill="currentColor">
+                        <path fillRule="evenodd" d="M10 9a3 3 0 100-6 3 3 0 000 6zm-7 9a7 7 0 1114 0H3z" clipRule="evenodd" />
+                      </svg>
+                      <span>Profile</span>
+                    </button>
+                  </li>
+                  <li>
+                    <button
+                      onClick={() => setActiveTab("appearance")}
+                      className={`w-full text-left px-4 py-3 flex items-center space-x-3 ${
+                        activeTab === "appearance"
+                          ? "bg-blue-50 dark:bg-blue-900/20 text-blue-600 dark:text-blue-400"
+                          : "hover:bg-gray-50 dark:hover:bg-gray-800/50"
+                      }`}
+                    >
+                      <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5" viewBox="0 0 20 20" fill="currentColor">
+                        <path fillRule="evenodd" d="M4 2a2 2 0 00-2 2v11a3 3 0 106 0V4a2 2 0 00-2-2H4zm1 14a1 1 0 100-2 1 1 0 000 2zm5-1.757l4.9-4.9a2 2 0 000-2.828L13.485 5.1a2 2 0 00-2.828 0L10 5.757v8.486zM16 18H9.071l6-6H16a2 2 0 012 2v2a2 2 0 01-2 2z" clipRule="evenodd" />
+                      </svg>
+                      <span>Appearance</span>
+                    </button>
+                  </li>
+                  <li>
+                    <button
+                      onClick={() => setActiveTab("notifications")}
+                      className={`w-full text-left px-4 py-3 flex items-center space-x-3 ${
+                        activeTab === "notifications"
+                          ? "bg-blue-50 dark:bg-blue-900/20 text-blue-600 dark:text-blue-400"
+                          : "hover:bg-gray-50 dark:hover:bg-gray-800/50"
+                      }`}
+                    >
+                      <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5" viewBox="0 0 20 20" fill="currentColor">
+                        <path d="M10 2a6 6 0 00-6 6v3.586l-.707.707A1 1 0 004 14h12a1 1 0 00.707-1.707L16 11.586V8a6 6 0 00-6-6zM10 18a3 3 0 01-3-3h6a3 3 0 01-3 3z" />
+                      </svg>
+                      <span>Notifications</span>
+                    </button>
+                  </li>
+                  <li>
+                    <button
+                      onClick={() => setActiveTab("integrations")}
+                      className={`w-full text-left px-4 py-3 flex items-center space-x-3 ${
+                        activeTab === "integrations"
+                          ? "bg-blue-50 dark:bg-blue-900/20 text-blue-600 dark:text-blue-400"
+                          : "hover:bg-gray-50 dark:hover:bg-gray-800/50"
+                      }`}
+                    >
+                      <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5" viewBox="0 0 20 20" fill="currentColor">
+                        <path fillRule="evenodd" d="M12.316 3.051a1 1 0 01.633 1.265l-4 12a1 1 0 11-1.898-.632l4-12a1 1 0 011.265-.633zM5.707 6.293a1 1 0 010 1.414L3.414 10l2.293 2.293a1 1 0 11-1.414 1.414l-3-3a1 1 0 010-1.414l3-3a1 1 0 011.414 0zm8.586 0a1 1 0 011.414 0l3 3a1 1 0 010 1.414l-3 3a1 1 0 11-1.414-1.414L16.586 10l-2.293-2.293a1 1 0 010-1.414z" clipRule="evenodd" />
+                      </svg>
+                      <span>Integrations</span>
+                    </button>
+                  </li>
+                  <li>
+                    <button
+                      onClick={() => setActiveTab("security")}
+                      className={`w-full text-left px-4 py-3 flex items-center space-x-3 ${
+                        activeTab === "security"
+                          ? "bg-blue-50 dark:bg-blue-900/20 text-blue-600 dark:text-blue-400"
+                          : "hover:bg-gray-50 dark:hover:bg-gray-800/50"
+                      }`}
+                    >
+                      <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5" viewBox="0 0 20 20" fill="currentColor">
+                        <path fillRule="evenodd" d="M2.166 4.999A11.954 11.954 0 0010 1.944 11.954 11.954 0 0017.834 5c.11.65.166 1.32.166 2.001 0 5.225-3.34 9.67-8 11.317C5.34 16.67 2 12.225 2 7c0-.682.057-1.35.166-2.001zm11.541 3.708a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clipRule="evenodd" />
+                      </svg>
+                      <span>Security</span>
+                    </button>
+                  </li>
+                </ul>
+              </nav>
+            </CardBody>
+          </Card>
+        </div>
+
+        {/* Settings Content */}
+        <div className="flex-1">
+          <Card>
+            <CardBody className="p-6">
+              {activeTab === "profile" && <ProfileSettings />}
+              {activeTab === "appearance" && <AppearanceSettings />}
+              {activeTab === "notifications" && <NotificationSettings />}
+              {activeTab === "integrations" && <IntegrationSettings />}
+              {activeTab === "security" && <SecuritySettings />}
+            </CardBody>
+          </Card>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
This PR adds a comprehensive settings page with the following features:

- Profile settings for managing GitHub profile information
- Appearance settings for customizing the UI theme and accessibility options
- Notification settings for managing notification preferences
- Integration settings for connecting with external services
- Security settings for managing account security and privacy

The settings page is accessible from both the sidebar navigation and the user dropdown menu in the header.